### PR TITLE
Fix: Remove Tailwind CSS configuration from Vite

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
-import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
     plugins: [
@@ -8,6 +7,5 @@ export default defineConfig({
             input: ['resources/sass/app.scss', 'resources/js/app.js'],
             refresh: true,
         }),
-        tailwindcss(),
     ],
 });


### PR DESCRIPTION
This pull request removes the `tailwindcss` plugin from the Vite configuration file, simplifying the build process.

* [`vite.config.js`](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26L3-L11): Removed the `tailwindcss` plugin from the list of plugins in the Vite configuration.