### PR TITLE
docs(README): Restructering and dev server quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,32 @@
 # Cleanup Laser Database
 
-## Description
+<!-- Add project description here -->
 
 ## Features
 
-## Dependencies
+<!-- Add key features here -->
 
-## Installation
+## Prerequisites
 
-### Development
+<!-- List dependencies and system requirements here -->
 
-#### Setting up the development environment
+## Quick Start
+
+Follow these steps to set up the development environment:
 
 1. Clone the repository.
-2. In the local repository, manually copy exisiting `.env.example` to new `.env` and configure your environment variables:
-    *e.g. for MySQL:*
-    - DB_CONNECTION=mysql
-    - DB_HOST=localhost
-    - DB_PORT=3306
-    - DB_DATABASE=[name of your new / existing database (not server name!)]
-    - DB_USERNAME=[`root` or your own username]
-    - DB_PASSWORD=[root password or your own password]
-3. Run `composer install` to install PHP dependencies.
-4. Run `npm install` to install JavaScript dependencies (will only work with [Node.js](https://nodejs.org/) installed).
-5. Run `npm run build` to generate the manifest file.
-6. Run `php artisan key:generate` to generate the application key.
-7. Run `php artisan migrate` to set up the database.
-8. Run `php artisan serve` to start the development server (will only work with the manifest file generated).
-9. Access the application at [http://localhost:8000](http://localhost:8000).
+2. Run `composer install` to install PHP dependencies.
+3. Run `npm install` to install JavaScript dependencies.
+4. Copy `.env.example` to `.env` and configure your environment variables.
+5. Run `php artisan key:generate` to generate the application key.
+6. Run `php artisan migrate` to set up the database.
+7. Run `composer run-script dev` to start the development server.
+8. Access the application at [http://localhost:8000](http://localhost:8000).
 
-#### Commands for database handling
+> [!TIP]
+> See [Development Environment Setup](https://github.com/McNamara84/cleanup-laser-database/wiki/Development-Environment-Setup) for detailed instructions.
+
+### Commands for database handling
 
 - `php artisan make:migration create_TABLENAME_table` to add a new migration for adding a new table.
 - `php artisan migrate:status` to show which migrations have run thus far.
@@ -39,18 +36,23 @@
 - `php artisan migrate:reset` to reset all migrations.
 - `php artisan migrate:fresh` to reset all migrations and newly execute all migrations.
 
-#### Commands for testing
+> [!TIP]
+> Detailed information about [migrations](https://github.com/McNamara84/cleanup-laser-database/wiki/Adding-a-new-table-with-a-new-migration) and [adding new models](https://github.com/McNamara84/cleanup-laser-database/wiki/Adding-new-models) can be found in the [Wiki](https://github.com/McNamara84/cleanup-laser-database/wiki).
+
+### Commands for testing
 
 - `php artisan serve` to start test server for manual testing
 - `php artisan test` to execute the test suite.
 
-### Production
+## Production Deployment
 
-This web application will be deployed automatically to the production server in VPN of University of Applied Sciences Potsdam using GitHub Actions. We will inform you about the public release later.
+This web application will be deployed automatically to the production server in the VPN of University of Applied Sciences Potsdam using GitHub Actions. We will inform you about the public release later.
 
-## Database
+## Database Schema
 
-### Main tables
+<!-- Introduction text for the db schema here -->
+
+### Core Tables
 
 - institutions
 - lenses
@@ -59,4 +61,12 @@ This web application will be deployed automatically to the production server in 
 
 ## Contributing
 
+<!-- Summarized conributing guidelines here -->
+
 ## Contact
+
+<!-- Add contact information -->
+
+## License
+
+<!-- Pick a license and explain and link it here -->


### PR DESCRIPTION

# Pull Request

## 📝 Was wurde geändert?

- Cleaned up the outline in `README.md` and updated the `Development` section (now called `Quick Start`).
It now shows the bare minimum commands for experienced users to start the dev server.
- It also mentions the correct command to start the server in development mode: Instead of just running the Laravel server (`php artisan serve`), one should run `composer run-script dev`, which runs Laravel and Vite concurrently and also provides hot reloading.
- New contriubtors should consult the in-depth guide in the wiki (https://github.com/McNamara84/cleanup-laser-database/wiki/Development-Environment-Setup).

## 🏷️ Art der Änderung
- [ ] 🐛 Bug Fix
- [ ] ✨ Neues Feature
- [ ] 💥 Breaking Change
- [x] 📚 Dokumentation
- [ ] ♻️ Refactoring
- [ ] 🎨 UI/Styling
- [ ] Dev Tooling

## 🔗 Issue
Closes #

## 🧪 Getestet
- [ ] Feature/Unit Tests laufen durch
- [ ] Tests hinzugefügt/aktualisiert
- [ ] Manuell getestet
- [ ] Browser-kompatibel
- [ ] Mobile-kompatibel
- [x] Definition of Done erfüllt

## 🚀 Laravel-spezifisch
- [ ] Migrations hinzugefügt/geändert
- [ ] Routes registriert
- [ ] Config-Änderungen dokumentiert
- [ ] Composer Dependencies aktualisiert
- [ ] Artisan Commands funktionieren

## 📷 Screenshots
<!-- Falls UI-Änderungen -->

## 💬 Notizen

I had to do a rebase and resolve a conflict. Hope the history isn't messed up too badly.
