### PR TITLE
fix/add-safety_class-to_devices-migration

### DIFF
--- a/database/migrations/2025_06_20_125906_add_safety_class_to_devices_table.php
+++ b/database/migrations/2025_06_20_125906_add_safety_class_to_devices_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->unsignedTinyInteger('safety_class')->nullable()->comment('e.g. 4');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('safety_class');
+
+        });
+    }
+};


### PR DESCRIPTION

# Pull Request

## 📝 What was changed?
I made an adjustment to the devices table because the safety_class attribute was missing. I noticed this while looking at the model file, where safety_class is listed in the array of casted attributes.

## 🏷️ Type of change
- [x] 🐛 Bug Fix (I guess?)
- [ ] ✨ New Feature
- [ ] 💥 Breaking Change
- [ ] 📚 Documentation
- [ ] ♻️ Refactoring
- [ ] 🎨 UI/Styling
- [ ] Dev Tooling

## 🔗 Issue
<!-- Closed Issues: "- Closes #…" -->

## 🧪 Testing
- [ ] Feature/Unit Tests pass
- [ ] Tests added/updated
- [x] Manually tested
- [ ] Browser compatible
- [ ] Mobile compatible
- [x] Definition of Done fulfilled

## 🚀 Laravel-specific
- [x] Migrations added/changed
- [ ] Routes registered
- [ ] Config changes documented
- [ ] Composer dependencies updated
- [ ] Artisan Commands work

## 📷 Screenshots
<!-- If UI changed -->

## 💬 Notes
<!-- Additional info for reviewers -->
