### PR TITLE
feat: create base layout for common content pages

### DIFF
--- a/resources/views/layouts/page/default.blade.php
+++ b/resources/views/layouts/page/default.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container my-5 pt-5 page-header">
+        <div class="row justify-content-center">
+            <div class="col-md-10">
+                <h1 class="mb-5 page-title">@yield('title')</h1>
+
+                @hasSection('excerpt')
+                    <div class="lead page-excerpt">
+                        @yield('excerpt')
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+
+    <div class="container my-5 page-body">
+        <div class="row justify-content-center">
+            <div class="col-md-10">
+                @yield('page-content')
+            </div>
+        </div>
+    </div>
+@endsection


### PR DESCRIPTION

# Pull Request

## 📝 What was changed?

`resources/views/layouts/page/default.blade.php` is supposed to act as a
base template for common pages with regular content like "about" or "privacy".
It itself extends the root layout `layouts/app.blade.php` and prodoes a
minimal layout structure for consuming pages.

The template provides the following sections:

- `title` inherited from parent
- `page-excerpt` for introduction text
- `page-content` for the main content

## 🔗 Issue
<!-- Closed Issues: "- Closes #…" -->

## 🧪 Definition of Done erfüllt?

- [ ] User story fulfilled
- [ ] Documentation updated
- [ ] New code is covered by unit tests
- [x] Unit tests locally pass
- [x] Manually tested
- [x] Browser compatible
- [x] Mobile compatible

## 🚀 Laravel-specific

- [ ] Migrations added/changed
- [ ] Models added/changed
- [ ] Views added/changed
- [ ] Routes registered
- [ ] Seeder added/changed
- [ ] Config changed
- [ ] Composer dependencies updated
- [ ] Artisan Commands added/changed

## 📷 Screenshots
<!-- If UI changed -->

## 💬 Notes
<!-- Additional info for reviewers -->
