### PR TITLE
Error codes with cats 

### DIFF
--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>404 Not Found</title>
+    <style>
+        body { text-align: center; font-family: sans-serif; margin-top: 50px; }
+    </style>
+</head>
+<body>
+    <h1>404 Not Found</h1>
+    <img src="https://live.staticflickr.com/5237/14088999339_e37c26afa6_b.jpg" alt="404 Cat" style="max-width:300px; border-radius:12px;">
+    <p class="attribution">"<a rel="noopener noreferrer" href="https://www.flickr.com/photos/26344495@N05/14088999339">Katze gähnt wie ein kleiner Tiger</a>" by <a rel="noopener noreferrer" href="https://www.flickr.com/photos/26344495@N05">Ivan Radic</a> is licensed under <a rel="noopener noreferrer" href="https://creativecommons.org/licenses/by/2.0/?ref=openverse">CC BY 2.0 <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /></a>.</p>
+    <p>Sorry, this page could not be found.</p>
+</body>
+</html>

--- a/resources/views/errors/419.blade.php
+++ b/resources/views/errors/419.blade.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>419 Page Expired</title>
+    <style>
+        body { text-align: center; font-family: sans-serif; margin-top: 50px; }
+    </style>
+</head>
+<body>
+    <h1>419 Page Expired</h1>
+    <img src="https://live.staticflickr.com/7536/15713818591_176fb37454_b.jpg" alt="419 Cat" style="max-width:300px; border-radius:12px;">
+    <p class="attribution">"<a rel="noopener noreferrer" href="https://www.flickr.com/photos/34530295@N06/15713818591">Angry Cat onto the Car</a>" by <a rel="noopener noreferrer" href="https://www.flickr.com/photos/34530295@N06">Yoshikazu TAKADA</a> is licensed under <a rel="noopener noreferrer" href="https://creativecommons.org/licenses/by/2.0/?ref=openverse">CC BY 2.0 <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /></a>.</p>
+    <p>Sorry, your session has expired. Please refresh the page and try again.</p>
+</body>
+</html>

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>500 Internal Server Error</title>
+    <style>
+        body { text-align: center; font-family: sans-serif; margin-top: 50px; }
+    </style>
+</head>
+<body>
+    <h1>500 Internal Server Error</h1>
+    <img src="https://live.staticflickr.com/244/515581633_ca6e075de1_b.jpg" alt="500 Cat" style="max-width:300px; border-radius:12px;">
+    <p class="attribution">"<a rel="noopener noreferrer" href="https://www.flickr.com/photos/82538355@N00/515581633">Angry cat wants water</a>" by <a rel="noopener noreferrer" href="https://www.flickr.com/photos/82538355@N00">spakattacks</a> is licensed under <a rel="noopener noreferrer" href="https://creativecommons.org/licenses/by/2.0/?ref=openverse">CC BY 2.0 <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /></a>.</p>
+    <p>Oops, something went wrong on our side.</p>
+</body>
+</html>

--- a/resources/views/errors/502.blade.php
+++ b/resources/views/errors/502.blade.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>502 Bad Gateway</title>
+    <style>
+        body { text-align: center; font-family: sans-serif; margin-top: 50px; }
+    </style>
+</head>
+<body>
+    <h1>502 Bad Gateway</h1>
+    <img src="https://live.staticflickr.com/5071/14203962451_fb91e9ccc7_b.jpg" alt="502 Cat" style="max-width:300px; border-radius:12px;">
+    <p class="attribution">"<a rel="noopener noreferrer" href="https://www.flickr.com/photos/26344495@N05/14203962451">Two colorful cats sleeping and cuddling on a couch</a>" by <a rel="noopener noreferrer" href="https://www.flickr.com/photos/26344495@N05">Ivan Radic</a> is licensed under <a rel="noopener noreferrer" href="https://creativecommons.org/licenses/by/2.0/?ref=openverse">CC BY 2.0 <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /><img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="height: 1em; margin-right: 0.125em; display: inline;" /></a>.</p>
+    <p>Oops, this is an invalid response!</p>
+</body>
+</html>


### PR DESCRIPTION
# Pull Request
the error codes: 404, 419, 500 and 502 are displayed now as cats

## 📝 What was changed?
<!-- Brief description of changes -->
unterordner errors wurde in der view angelegt mit den neuen views

## 🔗 Issue
- Closes #108 

## 🧪 Definition of Done erfüllt?

- [ ] User story fulfilled
- [ ] Documentation updated
- [ ] New code is covered by unit tests
- [ ] Unit tests locally pass
- [x] Manually tested
- [x] Browser compatible
- [ ] Mobile compatible

## 🚀 Laravel-specific

- [ ] Migrations added/changed
- [ ] Models added/changed
- [x] Views added/changed
- [ ] Routes registered
- [ ] Seeder added/changed
- [ ] Config changed
- [ ] Composer dependencies updated
- [ ] Artisan Commands added/changed

## 📷 Screenshots
<!-- If UI changed -->
<img width="1280" height="718" alt="Bildschirmfoto 2025-07-10 um 13 37 56" src="https://github.com/user-attachments/assets/48cae271-557b-43a1-a54d-2ec109d82135" />

## 💬 Notes
<!-- Additional info for reviewers -->
