### PR TITLE
chore: bump min php version from 8.2 to 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "wiki": "https://github.com/McNamara84/cleanup-laser-database/wiki"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "laravel/ui": "^4.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9588f20eeb5655c5e8190f46ce3cded",
+    "content-hash": "54d7b4dd02a6e5f548d1bd4133f6fec2",
     "packages": [
         {
             "name": "brick/math",
@@ -8161,7 +8161,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.3"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"


### PR DESCRIPTION
# Pull Request

## 📝 What was changed?

This PR bumps up the minimum required PHP version in `composer.json` from `8.2` to `8.3`.
Dependency versions were left untouched.

### Why

> PHP 8.3 and later support declaring a type for PHP Class constants. This ensures type compatibility of the constants when child classes and interface implementation override them.
> – https://php.watch/versions/8.3/typed-constants

## 🔗 Issue
<!-- Closed Issues: "- Closes #…" -->

## 🧪 Definition of Done erfüllt?

- [ ] User story fulfilled
- [ ] Documentation updated
- [ ] New code is covered by unit tests
- [x] Unit tests locally pass
- [x] Manually tested
- [ ] Browser compatible
- [ ] Mobile compatible

## 🚀 Laravel-specific

- [ ] Migrations added/changed
- [ ] Models added/changed
- [ ] Views added/changed
- [ ] Routes registered
- [ ] Seeder added/changed
- [ ] Config changed
- [ ] Composer dependencies updated
- [ ] Artisan Commands added/changed

## 📷 Screenshots
<!-- If UI changed -->

## 💬 Notes
<!-- Additional info for reviewers -->
