### PR TITLE
chore/add wiki to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-error.log
 /.zed
 /.cursor
 .DS_Store
+# Allow the GH Wiki as a nested Git Repository without being tracked
+/wiki


### PR DESCRIPTION
# Pull Request

GitHub Wikis live in their own Git repository usually named
`<user>/<repo>.wiki.git`. This seperation can make edits on the wiki
a bit cumbersome.

`/wiki` was added to `.gitignore` so that the wiki can be cloned into
a subdirectory of the main project without beeing tracked as part of the
code base.

## 📝 What was changed?

- `/wiki` was added to `.gitignore`

## 🔗 Issue
<!-- Closed Issues: "- Closes #…" -->

## 🧪 Definition of Done erfüllt?

- [ ] User story fulfilled
- [ ] Documentation updated
- [ ] New code is covered by unit tests
- [x] Unit tests locally pass
- [x] Manually tested
- [ ] Browser compatible
- [ ] Mobile compatible

## 🚀 Laravel-specific

- [ ] Migrations added/changed
- [ ] Models added/changed
- [ ] Views added/changed
- [ ] Routes registered
- [ ] Seeder added/changed
- [ ] Config changed
- [ ] Composer dependencies updated
- [ ] Artisan Commands added/changed

## 📷 Screenshots
<!-- If UI changed -->

## 💬 Notes
<!-- Additional info for reviewers -->
