### PR TITLE
Fix: Update Laravel ENV Variables in unittests Workflow

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -39,12 +39,12 @@ jobs:
         echo "APP_KEY=" >> .env
         echo "DB_CONNECTION=sqlite" >> .env
         echo "DB_DATABASE=database/testing.sqlite" >> .env
-        echo "CACHE_DRIVER=array" >> .env
+        echo "CACHE_STORE=array" >> .env
         echo "SESSION_DRIVER=array" >> .env
         echo "QUEUE_CONNECTION=sync" >> .env
         echo "LOG_CHANNEL=stderr" >> .env
         echo "MAIL_MAILER=array" >> .env
-        echo "BROADCAST_DRIVER=log" >> .env
+        echo "BROADCAST_CONNECTION=log" >> .env
 
     - name: Create SQLite database for testing
       run: |


### PR DESCRIPTION
# Pull Request

This pull request fixes an issue in the GitHub `unittests.yml` workflow.
The setup script used some legacy environment variables instead of the
names used in `.env.example` and in the files under `config/`.

One noticeable effect was that cache hits during boot would try to access
a database cache instead of the in-memory array store. This is doomed to fail
because migrations run after boot is triggered for the first time, thus there's
no `cache` table in the DB. (The code that triggered the cache lookup during
boot was also fixed.)

## 📝 What was changed?

- renamed `BOROADCAST_DRIVER` to `BROADCAST_CONNECTION`
- renamed `CACHE_DRIVER` to `CACHE_STORE`

## 🔗 Issue
<!-- Closed Issues: "- Closes #…" -->

## 🧪 Definition of Done erfüllt?

- [ ] User story fulfilled
- [ ] Documentation updated
- [ ] New code is covered by unit tests
- [x] Unit tests locally pass
- [ ] Manually tested
- [ ] Browser compatible
- [ ] Mobile compatible

## 🚀 Laravel-specific

- [ ] Migrations added/changed
- [ ] Models added/changed
- [ ] Views added/changed
- [ ] Routes registered
- [ ] Seeder added/changed
- [ ] Config changed
- [ ] Composer dependencies updated
- [ ] Artisan Commands added/changed

## 📷 Screenshots
<!-- If UI changed -->

## 💬 Notes
<!-- Additional info for reviewers -->
