### PR TITLE
Feature: Collapsible search filter

### DIFF
--- a/resources/js/searchFilters.js
+++ b/resources/js/searchFilters.js
@@ -49,3 +49,12 @@ document.addEventListener('DOMContentLoaded', function () {
         updateYearSlider(min);
     }
 });
+
+document.addEventListener('DOMContentLoaded', function () {
+    const filters = document.getElementById('searchFilters');
+    const toggle = document.querySelector('[data-bs-target="#searchFilters"]');
+    if (filters && toggle && window.matchMedia('(min-width: 768px)').matches) {
+        filters.classList.add('show');
+        toggle.setAttribute('aria-expanded', 'true');
+    }
+});

--- a/resources/js/searchFilters.js
+++ b/resources/js/searchFilters.js
@@ -56,5 +56,6 @@ document.addEventListener('DOMContentLoaded', function () {
     if (filters && toggle && window.matchMedia('(min-width: 768px)').matches) {
         filters.classList.add('show');
         toggle.setAttribute('aria-expanded', 'true');
+        toggle.classList.remove('collapsed');
     }
 });

--- a/resources/js/searchFilters.js
+++ b/resources/js/searchFilters.js
@@ -57,18 +57,18 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!filters || !toggle) return;
 
     function setExpanded(expanded) {
-        toggle.setAttribute('aria-expanded', expanded);
+        toggle.setAttribute('aria-expanded', expanded.toString());
         toggle.setAttribute('aria-label', expanded ? 'Filter ausblenden' : 'Filter einblenden');
     }
 
-    filters.addEventListener('shown.bs.collapse', () => setExpanded('true'));
-    filters.addEventListener('hidden.bs.collapse', () => setExpanded('false'));
+    filters.addEventListener('shown.bs.collapse', () => setExpanded(true));
+    filters.addEventListener('hidden.bs.collapse', () => setExpanded(false));
 
     if (window.matchMedia('(min-width: 768px)').matches) {
         filters.classList.add('show');
         toggle.classList.remove('collapsed');
-        setExpanded('true');
+        setExpanded(true);
     } else {
-        setExpanded('false');
+        setExpanded(false);
     }
 });

--- a/resources/js/searchFilters.js
+++ b/resources/js/searchFilters.js
@@ -53,9 +53,22 @@ document.addEventListener('DOMContentLoaded', function () {
 document.addEventListener('DOMContentLoaded', function () {
     const filters = document.getElementById('searchFilters');
     const toggle = document.querySelector('[data-bs-target="#searchFilters"]');
-    if (filters && toggle && window.matchMedia('(min-width: 768px)').matches) {
+
+    if (!filters || !toggle) return;
+
+    function setExpanded(expanded) {
+        toggle.setAttribute('aria-expanded', expanded);
+        toggle.setAttribute('aria-label', expanded ? 'Filter ausblenden' : 'Filter einblenden');
+    }
+
+    filters.addEventListener('shown.bs.collapse', () => setExpanded('true'));
+    filters.addEventListener('hidden.bs.collapse', () => setExpanded('false'));
+
+    if (window.matchMedia('(min-width: 768px)').matches) {
         filters.classList.add('show');
-        toggle.setAttribute('aria-expanded', 'true');
         toggle.classList.remove('collapsed');
+        setExpanded('true');
+    } else {
+        setExpanded('false');
     }
 });

--- a/resources/sass/_filters.scss
+++ b/resources/sass/_filters.scss
@@ -22,3 +22,11 @@
     pointer-events: all;
     position: relative;
 }
+
+.filter-toggle .bi-chevron-down {
+    transition: transform 0.2s ease;
+}
+
+.filter-toggle:not(.collapsed) .bi-chevron-down {
+    transform: rotate(180deg);
+}

--- a/resources/views/partials/_svg-sprite.blade.php
+++ b/resources/views/partials/_svg-sprite.blade.php
@@ -40,6 +40,10 @@
         <path fill-rule="evenodd"
             d="M11.5 2a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3M9.05 3a2.5 2.5 0 0 1 4.9 0H16v1h-2.05a2.5 2.5 0 0 1-4.9 0H0V3zM4.5 7a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3M2.05 8a2.5 2.5 0 0 1 4.9 0H16v1H6.95a2.5 2.5 0 0 1-4.9 0H0V8zm9.45 4a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3m-2.45 1a2.5 2.5 0 0 1 4.9 0H16v1h-2.05a2.5 2.5 0 0 1-4.9 0H0v-1z" />
     </symbol>
+    <!-- Chevron Down Icon -->
+    <symbol id="bi-chevron-down" viewBox="0 0 16 16">
+        <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708" />
+    </symbol>
     <!-- Logout Icon -->
     <symbol id="bi-box-arrow-right" viewBox="0 0 16 16">
         <path fill-rule="evenodd"

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -6,12 +6,12 @@
     <div class="container py-4">
         <div class="row">
             <aside class="col-md-3 mb-4">
-                <button class="btn btn-outline-secondary w-100 mb-3 d-md-none" type="button"
+                <button class="btn btn-outline-secondary w-100 mb-3" type="button"
                         data-bs-toggle="collapse" data-bs-target="#searchFilters" aria-expanded="false"
                         aria-controls="searchFilters">
                     Filter
                 </button>
-                <div id="searchFilters" class="collapse d-md-block">
+                <div id="searchFilters" class="collapse">
                     @include('search._filters')
                 </div>
             </aside>

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -6,10 +6,11 @@
     <div class="container py-4">
         <div class="row">
             <aside class="col-md-3 mb-4">
-                <button class="btn btn-outline-secondary w-100 mb-3" type="button"
+                <button class="btn btn-outline-secondary w-100 mb-3 d-flex justify-content-between align-items-center filter-toggle collapsed" type="button"
                         data-bs-toggle="collapse" data-bs-target="#searchFilters" aria-expanded="false"
                         aria-controls="searchFilters">
-                    Filter
+                    <span><x-icon icon="bi-sliders" class="me-2" />Filter</span>
+                    <x-icon icon="bi-chevron-down" />
                 </button>
                 <div id="searchFilters" class="collapse">
                     @include('search._filters')

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -6,13 +6,13 @@
     <div class="container py-4">
         <div class="row">
             <aside class="col-md-3 mb-4">
-                <button class="btn btn-outline-secondary w-100 mb-3 d-flex justify-content-between align-items-center filter-toggle collapsed" type="button"
+                <button id="searchFiltersToggle" class="btn btn-outline-secondary w-100 mb-3 d-flex justify-content-between align-items-center filter-toggle collapsed" type="button"
                         data-bs-toggle="collapse" data-bs-target="#searchFilters" aria-expanded="false"
-                        aria-controls="searchFilters">
+                        aria-controls="searchFilters" aria-label="Filter einblenden">
                     <span><x-icon icon="bi-sliders" class="me-2" />Filter</span>
                     <x-icon icon="bi-chevron-down" />
                 </button>
-                <div id="searchFilters" class="collapse">
+                <div id="searchFilters" class="collapse" role="region" aria-labelledby="searchFiltersToggle">
                     @include('search._filters')
                 </div>
             </aside>

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -6,7 +6,14 @@
     <div class="container py-4">
         <div class="row">
             <aside class="col-md-3 mb-4">
-                @include('search._filters')
+                <button class="btn btn-outline-secondary w-100 mb-3 d-md-none" type="button"
+                        data-bs-toggle="collapse" data-bs-target="#searchFilters" aria-expanded="false"
+                        aria-controls="searchFilters">
+                    Filter
+                </button>
+                <div id="searchFilters" class="collapse d-md-block">
+                    @include('search._filters')
+                </div>
             </aside>
             <div class="col-md-9">
                 @if($query)

--- a/tests/Feature/SearchFilterCollapseTest.php
+++ b/tests/Feature/SearchFilterCollapseTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Device;
+use App\Models\Institution;
+
+class SearchFilterCollapseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_search_results_page_contains_collapsible_filter_toggle(): void
+    {
+        $response = $this->get('/adv-search/result');
+
+        $response->assertStatus(200);
+
+        $html = $response->getContent();
+
+        $dom = new \DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($html);
+        libxml_clear_errors();
+
+        $toggle = $dom->getElementById('searchFiltersToggle');
+        $this->assertNotNull($toggle);
+        $this->assertEquals('button', $toggle->tagName);
+        $this->assertEquals('collapse', $toggle->getAttribute('data-bs-toggle'));
+        $this->assertEquals('#searchFilters', $toggle->getAttribute('data-bs-target'));
+        $this->assertEquals('searchFilters', $toggle->getAttribute('aria-controls'));
+        $this->assertEquals('false', $toggle->getAttribute('aria-expanded'));
+        $this->assertEquals('Filter einblenden', $toggle->getAttribute('aria-label'));
+    }
+
+    public function test_search_results_page_contains_filter_region(): void
+    {
+        $response = $this->get('/adv-search/result');
+
+        $response->assertStatus(200);
+
+        $html = $response->getContent();
+
+        $dom = new \DOMDocument();
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($html);
+        libxml_clear_errors();
+
+        $filters = $dom->getElementById('searchFilters');
+        $this->assertNotNull($filters);
+        $this->assertStringContainsString('collapse', $filters->getAttribute('class'));
+        $this->assertEquals('region', $filters->getAttribute('role'));
+        $this->assertEquals('searchFiltersToggle', $filters->getAttribute('aria-labelledby'));
+    }
+}


### PR DESCRIPTION
# Pull Request
This pull request introduces a collapsible filter sidebar to the search results page, improving usability on smaller screens and enhancing accessibility. The sidebar can now be toggled open or closed via a button, which also provides clear visual feedback and ARIA attributes for screen readers. Supporting CSS, SVG icons, and automated tests have been added to ensure a smooth user experience and maintain accessibility standards.

## 📝 What was changed?
### Collapsible Filter Sidebar Implementation
* Added a toggle button (`searchFiltersToggle`) above the filter sidebar in `search/index.blade.php`, with ARIA attributes and a chevron icon for visual feedback. The filter content is now wrapped in a collapsible region (`searchFilters`).
* Implemented JavaScript logic in `searchFilters.js` to synchronize the toggle button state, ARIA attributes, and filter visibility, including responsive behavior for desktop and mobile screens.

### Visual and Accessibility Enhancements
* Added a chevron-down SVG icon to `_svg-sprite.blade.php` for use in the filter toggle button.
* Updated filter toggle CSS in `_filters.scss` to animate the chevron icon when the sidebar is expanded or collapsed.

### Testing
* Added a feature test (`SearchFilterCollapseTest.php`) to verify the presence and correct configuration of the collapsible filter toggle and filter region on the search results page.

## 🔗 Issue
- Closes #165 

## 🧪 Definition of Done erfüllt?

- [x] User story fulfilled
- [x] Documentation updated
- [x] New code is covered by unit tests
- [x] Unit tests locally pass
- [x] Manually tested
- [x] Browser compatible
- [x] Mobile compatible

## 🚀 Laravel-specific

- [ ] Migrations added/changed
- [ ] Models added/changed
- [x] Views added/changed
- [ ] Routes registered
- [ ] Seeder added/changed
- [ ] Config changed
- [ ] Composer dependencies updated
- [ ] Artisan Commands added/changed

## 📷 Screenshots
Default search result page on desktop:

<img width="1361" height="938" alt="image" src="https://github.com/user-attachments/assets/4b31150b-cd76-4075-8717-31f2c7599ced" />

Default search result page on mobile:

<img width="382" height="850" alt="image" src="https://github.com/user-attachments/assets/6bebae94-3b76-48f9-8875-fc5a623db959" />

## 💬 Notes
<!-- Additional info for reviewers -->
