### PR TITLE
Fix: Add institution selection to device input form

### DIFF
--- a/app/Http/Controllers/InputFormDeviceController.php
+++ b/app/Http/Controllers/InputFormDeviceController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
 use App\Models\Device;
+use App\Models\Institution;
 
 class InputFormDeviceController extends Controller
 {
@@ -13,8 +14,9 @@ class InputFormDeviceController extends Controller
     public function index()
     {
         $pageTitle = 'Input Form - LADIS - FH Potsdam';
+        $institutions = Institution::orderBy('name')->get();
 
-        return view('inputform_device', compact('pageTitle'));
+        return view('inputform_device', compact('pageTitle', 'institutions'));
     }
 
     /**
@@ -32,6 +34,7 @@ class InputFormDeviceController extends Controller
             'build' => 'nullable|integer|in:0,1',
             'safety_class' => 'nullable|integer|min:1|max:4',
             'description' => 'nullable|string',
+            'institution_id' => 'required|exists:institutions,id',
             
             // Dimensions
             'height' => 'nullable|integer|min:0',
@@ -69,10 +72,6 @@ class InputFormDeviceController extends Controller
             'min_focal_length' => 'nullable|numeric|min:0',
             'max_focal_length' => 'nullable|numeric|min:0',
         ]);
-
-        // Add Institution ID (temporarily hardcoded)
-        // TODO: Later we get this from form
-        $validatedData['institution_id'] = 1; // Temporarily hardcoded
         
         // Add User ID (temporarily hardcoded)
         // TODO: Later we get this from Auth::user()

--- a/resources/views/inputform_device.blade.php
+++ b/resources/views/inputform_device.blade.php
@@ -40,7 +40,15 @@
                                             Bitte geben Sie eine eindeutige Bezeichnung für das Lasergerät an, z.B. CL50.
                                         </div>
                                     </div>
-
+                                    <div class="form-group mb-3">
+                                        <label for="institution_id" class="form-label">Institution *</label>
+                                        <select class="form-control @error('institution_id') is-invalid @enderror" id="institution_id" name="institution_id" required>
+                                            <option value="">Bitte auswählen</option>
+                                            @foreach($institutions as $institution)
+                                                <option value="{{ $institution->id }}" @selected(old('institution_id') == $institution->id)>{{ $institution->name }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
                                     <div class="form-group mb-3">
                                         <label for="year" class="form-label">Gerätejahr *</label>
                                         <input type="number" class="form-control @error('year') is-invalid @enderror"

--- a/tests/Feature/DeviceFormTest.php
+++ b/tests/Feature/DeviceFormTest.php
@@ -47,6 +47,7 @@ class DeviceFormTest extends TestCase
             'build' => Device::BUILD_FIBER, // Glasfaser
             'safety_class' => 2,
             'description' => 'Test Lasergerät für Unit Tests',
+            'institution_id' => $this->institution->id,
             'height' => 1200,
             'width' => 800,
             'depth' => 600,
@@ -91,7 +92,7 @@ class DeviceFormTest extends TestCase
             'build' => Device::BUILD_FIBER,
             'safety_class' => 2,
             'beam_type' => Device::BEAM_POINT,
-            'institution_id' => 1, // Hardcoded in Controller TODO: Later we get this from form
+            'institution_id' => $this->institution->id,
             'last_edit_by' => 1,   // Hardcoded in Controller TODO: Later we get this from Auth::user()
         ]);
 
@@ -112,6 +113,7 @@ class DeviceFormTest extends TestCase
         $deviceData = [
             // 'name' => 'Test Device', // Missing on purpose
             'beam_type' => Device::BEAM_POINT,
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
@@ -129,6 +131,7 @@ class DeviceFormTest extends TestCase
         $deviceData = [
             'name' => 'Test Device',
             // 'beam_type' => 0, // Missing on purpose
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
@@ -151,6 +154,7 @@ class DeviceFormTest extends TestCase
         $deviceData = [
             'name' => 'Unique Device', // Same name as first Device
             'beam_type' => Device::BEAM_POINT,
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
@@ -169,6 +173,7 @@ class DeviceFormTest extends TestCase
             'build' => 99,      // Unallowed value (only 0,1 allowed)
             'beam_type' => 99,  // Unallowed value (only 0,1,2 allowed)
             'cooling' => 99,    // Unallowed value (only 0,1 allowed)
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
@@ -192,6 +197,7 @@ class DeviceFormTest extends TestCase
             'fiber_length' => -5.0, // signed
             'max_output' => -100,   // signed
             'wavelength' => -1064,  // signed
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
@@ -211,6 +217,7 @@ class DeviceFormTest extends TestCase
             'head' => str_repeat('B', 51),           // Max. 50 chars
             'beam_profile' => str_repeat('C', 51),   // Max. 50 chars
             'beam_type' => Device::BEAM_POINT,
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
@@ -231,6 +238,7 @@ class DeviceFormTest extends TestCase
             'cooling' => Device::COOLING_EXTERNAL, // Max. allowed
             'height' => 1, // Min. > 0
             'width' => 999999, // Large value, but should be valid
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
@@ -249,6 +257,7 @@ class DeviceFormTest extends TestCase
         $deviceData = [
             'name' => 'Minimal Device', // Required field
             'beam_type' => Device::BEAM_LINE, // Required field
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
@@ -259,6 +268,7 @@ class DeviceFormTest extends TestCase
         $this->assertDatabaseHas('devices', [
             'name' => 'Minimal Device',
             'beam_type' => Device::BEAM_LINE,
+            'institution_id' => $this->institution->id,
         ]);
         
         $device = Device::first();
@@ -275,6 +285,7 @@ class DeviceFormTest extends TestCase
             'beam_type' => Device::BEAM_POINT,
             'mounting' => 1,    // true
             'automation' => 0,  // false
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
@@ -286,10 +297,11 @@ class DeviceFormTest extends TestCase
 
         // Test case with mounting=false, automation=true
         $deviceData2 = [
-            'name' => 'Boolean Test 2', 
+            'name' => 'Boolean Test 2',
             'beam_type' => Device::BEAM_POINT,
             'mounting' => 0,    // false
             'automation' => 1,  // true
+            'institution_id' => $this->institution->id,
         ];
 
         $this->post(route('inputform.store'), $deviceData2);
@@ -315,17 +327,18 @@ class DeviceFormTest extends TestCase
         
         // Delete all institutions if any exists
         Institution::query()->delete();
-        
+
         $deviceData = [
             'name' => 'Exception Test',
             'beam_type' => Device::BEAM_POINT,
+            'institution_id' => $this->institution->id,
         ];
 
         $response = $this->post(route('inputform.store'), $deviceData);
 
-        // Check if we get redirected back with an error message
+        // Check if validation catches missing institution
         $response->assertRedirect();
-        $response->assertSessionHas('error');
+        $response->assertSessionHasErrors(['institution_id']);
         $this->assertDatabaseCount('devices', 0);
     }
 }

--- a/tests/Feature/DeviceTest.php
+++ b/tests/Feature/DeviceTest.php
@@ -107,8 +107,9 @@ class DeviceTest extends TestCase
 
     public function test_fillable_and_casts_are_defined(): void
     {
+        $institution = Institution::factory()->create();
         $device = new Device([
-            'institution_id' => '1',
+            'institution_id' => $institution->id,
             'name' => 'Test',
             'beam_type' => Device::BEAM_POINT,
             'mounting' => '1',


### PR DESCRIPTION
This pull request introduces support for associating devices with institutions in the device input form and backend logic. It updates both the controller and view to handle institution selection, ensures validation, and revises tests to reflect the new required field.

## Changes & Rationale
### Form and Controller Updates
* Added an institution dropdown to the device input form, populated from the `institutions` table, and passed the institutions data from the controller to the view (`inputform_device.blade.php`, `InputFormDeviceController.php`). [[1]](diffhunk://#diff-c0fc7828fc69e4f1c4b95e36bcd5dd17a6c3307bf444c3e2440651e42b7c0709R9-R19) [[2]](diffhunk://#diff-2a8d45f74bd029707deeaa5dc00cabbf356be1cdf17f3b82537759dc1206904fL43-R51)
* Updated validation rules to require a valid `institution_id` and removed the previous hardcoded value in the controller (`InputFormDeviceController.php`). [[1]](diffhunk://#diff-c0fc7828fc69e4f1c4b95e36bcd5dd17a6c3307bf444c3e2440651e42b7c0709R37) [[2]](diffhunk://#diff-c0fc7828fc69e4f1c4b95e36bcd5dd17a6c3307bf444c3e2440651e42b7c0709L73-L76)

### Test Suite Updates
* Modified all relevant feature tests to include `institution_id`, using a dynamically created institution instead of a hardcoded value (`DeviceFormTest.php`). [[1]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR50) [[2]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eL94-R95) [[3]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR116) [[4]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR134) [[5]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR157) [[6]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR176) [[7]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR200) [[8]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR220) [[9]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR241) [[10]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR260) [[11]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR271) [[12]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR288) [[13]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR304) [[14]](diffhunk://#diff-ee630e0f51c93eda88d3548f805eb1bf2020c75cef9472c361ece1b9a7c4cc8eR334-R341)
* Updated the database exception test to assert proper validation error for missing `institution_id` instead of a generic error (`DeviceFormTest.php`).
* Updated device model attribute tests to use a dynamically created institution (`DeviceTest.php`).

<!-- Example:
### Some change

- Description of the edits made
- …

<details>
<summary>Additional screenshots</summary>
    …
</details>
-->

## Related Issues
<!-- Example: Closes #123, Fixes #456 -->

## Definition of Done Checklist

- [ ] User story requirements met
- [ ] Documentation updated
- [x] New code covered by unit tests
- [x] All unit tests pass locally
- [x] Manually tested
- [x] Works on desktop devices
- [x] Works on mobile devices

## Laravel-Specific Changes

- [ ] Migrations
- [ ] Models
- [x] Views
- [ ] Routes
- [ ] Seeders
- [ ] Config
- [ ] Artisan commands

## Infrastructure & Tooling Changes

- [ ] PHP dependencies
- [ ] Node.js dependencies
- [ ] Tooling/scripts
- [ ] CI/CD workflows
- [ ] Repository meta/templates

## Additional Notes
<!-- Add any extra context for reviewers and contributors -->
