### PR TITLE
Fix: Enforce strict email validation in user creation

### DIFF
--- a/app/Http/Controllers/UserManagementController.php
+++ b/app/Http/Controllers/UserManagementController.php
@@ -27,7 +27,7 @@ class UserManagementController extends Controller
     {
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email' => ['required', 'string', 'email:strict', 'max:255', 'unique:users'],
         ]);
 
         $user = User::create([

--- a/tests/Feature/UserManagementControllerTest.php
+++ b/tests/Feature/UserManagementControllerTest.php
@@ -53,6 +53,21 @@ class UserManagementControllerTest extends TestCase
         $this->assertNotNull($user->password);
     }
 
+    public function test_store_rejects_invalid_email(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $response = $this->withHeader('referer', '/user-management/create')
+            ->post('/user-management/create', [
+                'name' => 'Invalid Email',
+                'email' => 'alice@wonderland',
+            ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasErrors(['email']);
+        $this->assertDatabaseMissing('users', ['email' => 'alice@wonderland']);
+    }
+
     public function test_destroy_deletes_user_and_redirects(): void
     {
         User::factory()->create(['id' => 1]);


### PR DESCRIPTION
This pull request strengthens email validation in user creation and adds a corresponding test to ensure invalid emails are properly rejected.

## Changes & Rationale
### Validation improvements
* Updated the email validation rule in `UserManagementController.php` to use `email:strict`, enforcing stricter email format checks.

### Test coverage
* Added a new test `test_store_rejects_invalid_email` in `UserManagementControllerTest.php` to verify that invalid emails are rejected, the user is not created, and an error is shown.

<!-- Example:
### Some change

- Description of the edits made
- …

<details>
<summary>Additional screenshots</summary>
    …
</details>
-->

## Related Issues
- Closes #194 

## Definition of Done Checklist

- [x] User story requirements met
- [x] Documentation updated
- [x] New code covered by unit tests
- [x] All unit tests pass locally
- [x] Manually tested
- [x] Works on desktop devices
- [x] Works on mobile devices

## Laravel-Specific Changes

- [ ] Migrations
- [ ] Models
- [ ] Views
- [ ] Routes
- [ ] Seeders
- [ ] Config
- [ ] Artisan commands

## Infrastructure & Tooling Changes

- [ ] PHP dependencies
- [ ] Node.js dependencies
- [ ] Tooling/scripts
- [ ] CI/CD workflows
- [ ] Repository meta/templates

## Additional Notes
<!-- Add any extra context for reviewers and contributors -->
