### PR TITLE
Feature: Delete modal as blade component

### DIFF
--- a/resources/views/artifacts/index.blade.php
+++ b/resources/views/artifacts/index.blade.php
@@ -30,28 +30,13 @@
                                     <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#deleteArtifact{{ $artifact->id }}">
                                         Löschen
                                     </button>
-
-                                    <div class="modal fade" id="deleteArtifact{{ $artifact->id }}" tabindex="-1" aria-labelledby="deleteArtifact{{ $artifact->id }}Label" aria-hidden="true">
-                                        <div class="modal-dialog">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title" id="deleteArtifact{{ $artifact->id }}Label">Objekt löschen</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    Soll das Objekt <strong>{{ $artifact->name }}</strong> wirklich gelöscht werden?
-                                                </div>
-                                                <div class="modal-footer">
-                                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
-                                                    <form method="POST" action="{{ route('artifacts.destroy', $artifact->id) }}" class="d-inline">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit" class="btn btn-danger">Löschen</button>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    @component('components.delete-modal', [
+                                        'modalId' => 'deleteArtifact' . $artifact->id,
+                                        'title' => 'Objekt löschen',
+                                        'message' => 'Soll das Objekt <strong>' . e($artifact->name) . '</strong> wirklich gelöscht werden?',
+                                        'actionRoute' => route('artifacts.destroy', $artifact->id),
+                                    ])
+                                    @endcomponent
                                 </td>
                             @endauth
                         </tr>

--- a/resources/views/components/delete-modal.blade.php
+++ b/resources/views/components/delete-modal.blade.php
@@ -1,0 +1,23 @@
+@props(['modalId', 'title', 'message', 'actionRoute'])
+
+<div class="modal fade" id="{{ $modalId }}" tabindex="-1" aria-labelledby="{{ $modalId }}Label" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="{{ $modalId }}Label">{{ $title }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
+            </div>
+            <div class="modal-body">
+                {!! $message !!}
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
+                <form method="POST" action="{{ $actionRoute }}" class="d-inline">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger">Löschen</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/devices/index.blade.php
+++ b/resources/views/devices/index.blade.php
@@ -36,28 +36,13 @@
                                     <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#deleteDevice{{ $device->id }}">
                                         Löschen
                                     </button>
-
-                                    <div class="modal fade" id="deleteDevice{{ $device->id }}" tabindex="-1" aria-labelledby="deleteDevice{{ $device->id }}Label" aria-hidden="true">
-                                        <div class="modal-dialog">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title" id="deleteDevice{{ $device->id }}Label">Gerät löschen</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    Soll das Gerät <strong>{{ $device->name }}</strong> wirklich gelöscht werden?
-                                                </div>
-                                                <div class="modal-footer">
-                                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
-                                                    <form method="POST" action="{{ route('devices.destroy', $device->id) }}" class="d-inline">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit" class="btn btn-danger">Löschen</button>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    @component('components.delete-modal', [
+                                        'modalId' => 'deleteDevice' . $device->id,
+                                        'title' => 'Gerät löschen',
+                                        'message' => 'Soll das Gerät <strong>' . e($device->name) . '</strong> wirklich gelöscht werden?',
+                                        'actionRoute' => route('devices.destroy', $device->id),
+                                    ])
+                                    @endcomponent
                                 </td>
                             @endauth
                         </tr>

--- a/resources/views/institutions/index.blade.php
+++ b/resources/views/institutions/index.blade.php
@@ -43,27 +43,13 @@
                                     <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#deleteInstitution{{ $institution->id }}">
                                         Löschen
                                     </button>
-                                    <div class="modal fade" id="deleteInstitution{{ $institution->id }}" tabindex="-1" aria-labelledby="deleteInstitution{{ $institution->id }}Label" aria-hidden="true">
-                                        <div class="modal-dialog">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title" id="deleteInstitution{{ $institution->id }}Label">Institution löschen</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schliessen"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    Soll die Institution <strong>{{ $institution->name }}</strong> wirklich gelöscht werden?
-                                                </div>
-                                                <div class="modal-footer">
-                                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
-                                                    <form method="POST" action="{{ route('institutions.destroy', $institution->id) }}" class="d-inline">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit" class="btn btn-danger">Löschen</button>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    @component('components.delete-modal', [
+                                        'modalId' => 'deleteInstitution' . $institution->id,
+                                        'title' => 'Institution löschen',
+                                        'message' => 'Soll die Institution <strong>' . e($institution->name) . '</strong> wirklich gelöscht werden?',
+                                        'actionRoute' => route('institutions.destroy', $institution->id),
+                                    ])
+                                    @endcomponent
                                 </td>
                             @endauth
                         </tr>

--- a/resources/views/materials/index.blade.php
+++ b/resources/views/materials/index.blade.php
@@ -28,28 +28,13 @@
                                     <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#deleteMaterial{{ $material->id }}">
                                         Löschen
                                     </button>
-
-                                    <div class="modal fade" id="deleteMaterial{{ $material->id }}" tabindex="-1" aria-labelledby="deleteMaterial{{ $material->id }}Label" aria-hidden="true">
-                                        <div class="modal-dialog">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title" id="deleteMaterial{{ $material->id }}Label">Material löschen</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    Soll das Material <strong>{{ $material->name }}</strong> wirklich gelöscht werden?
-                                                </div>
-                                                <div class="modal-footer">
-                                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
-                                                    <form method="POST" action="{{ route('materials.destroy', $material->id) }}" class="d-inline">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit" class="btn btn-danger">Löschen</button>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    @component('components.delete-modal', [
+                                        'modalId' => 'deleteMaterial' . $material->id,
+                                        'title' => 'Material löschen',
+                                        'message' => 'Soll das Material <strong>' . e($material->name) . '</strong> wirklich gelöscht werden?',
+                                        'actionRoute' => route('materials.destroy', $material->id),
+                                    ])
+                                    @endcomponent
                                 </td>
                             @endauth
                         </tr>
@@ -63,28 +48,13 @@
                                         <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#deleteMaterial{{ $child->id }}">
                                             Löschen
                                         </button>
-
-                                        <div class="modal fade" id="deleteMaterial{{ $child->id }}" tabindex="-1" aria-labelledby="deleteMaterial{{ $child->id }}Label" aria-hidden="true">
-                                            <div class="modal-dialog">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <h5 class="modal-title" id="deleteMaterial{{ $child->id }}Label">Material löschen</h5>
-                                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
-                                                    </div>
-                                                    <div class="modal-body">
-                                                        Soll das Material <strong>{{ $child->name }}</strong> wirklich gelöscht werden?
-                                                    </div>
-                                                    <div class="modal-footer">
-                                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
-                                                        <form method="POST" action="{{ route('materials.destroy', $child->id) }}" class="d-inline">
-                                                            @csrf
-                                                            @method('DELETE')
-                                                            <button type="submit" class="btn btn-danger">Löschen</button>
-                                                        </form>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
+                                        @component('components.delete-modal', [
+                                            'modalId' => 'deleteMaterial' . $child->id,
+                                            'title' => 'Material löschen',
+                                            'message' => 'Soll das Material <strong>' . e($child->name) . '</strong> wirklich gelöscht werden?',
+                                            'actionRoute' => route('materials.destroy', $child->id),
+                                        ])
+                                        @endcomponent
                                     </td>
                                 @endauth
                             </tr>

--- a/resources/views/persons/index.blade.php
+++ b/resources/views/persons/index.blade.php
@@ -28,28 +28,13 @@
                                     <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#deletePerson{{ $person->id }}">
                                         Löschen
                                     </button>
-
-                                    <div class="modal fade" id="deletePerson{{ $person->id }}" tabindex="-1" aria-labelledby="deletePerson{{ $person->id }}Label" aria-hidden="true">
-                                        <div class="modal-dialog">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title" id="deletePerson{{ $person->id }}Label">Person löschen</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    Soll die Person <strong>{{ $person->name }}</strong> wirklich gelöscht werden?
-                                                </div>
-                                                <div class="modal-footer">
-                                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
-                                                    <form method="POST" action="{{ route('persons.destroy', $person->id) }}" class="d-inline">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit" class="btn btn-danger">Löschen</button>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    @component('components.delete-modal', [
+                                        'modalId' => 'deletePerson' . $person->id,
+                                        'title' => 'Person löschen',
+                                        'message' => 'Soll die Person <strong>' . e($person->name) . '</strong> wirklich gelöscht werden?',
+                                        'actionRoute' => route('persons.destroy', $person->id),
+                                    ])
+                                    @endcomponent
                                 </td>
                             @endauth
                         </tr>

--- a/resources/views/processes/index.blade.php
+++ b/resources/views/processes/index.blade.php
@@ -36,33 +36,13 @@
                                         data-bs-target="#deleteProcess{{ $process->id }}">
                                         Löschen
                                     </button>
-
-                                    <div class="modal fade" id="deleteProcess{{ $process->id }}" tabindex="-1"
-                                        aria-labelledby="deleteProcess{{ $process->id }}Label" aria-hidden="true">
-                                        <div class="modal-dialog">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title" id="deleteProcess{{ $process->id }}Label">Prozess
-                                                        löschen</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal"
-                                                        aria-label="Schließen"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    Soll der Prozess <strong>{{ $process->id }}</strong> wirklich gelöscht werden?
-                                                </div>
-                                                <div class="modal-footer">
-                                                    <button type="button" class="btn btn-secondary"
-                                                        data-bs-dismiss="modal">Abbrechen</button>
-                                                    <form method="POST" action="{{ route('processes.destroy', $process->id) }}"
-                                                        class="d-inline">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit" class="btn btn-danger">Löschen</button>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    @component('components.delete-modal', [
+                                        'modalId' => 'deleteProcess' . $process->id,
+                                        'title' => 'Prozess löschen',
+                                        'message' => 'Soll der Prozess <strong>' . $process->id . '</strong> wirklich gelöscht werden?',
+                                        'actionRoute' => route('processes.destroy', $process->id),
+                                    ])
+                                    @endcomponent
                                 </td>
                             @endauth
                         </tr>

--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -34,28 +34,13 @@
                                     <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#deleteProject{{ $project->id }}">
                                         Löschen
                                     </button>
-
-                                    <div class="modal fade" id="deleteProject{{ $project->id }}" tabindex="-1" aria-labelledby="deleteProject{{ $project->id }}Label" aria-hidden="true">
-                                        <div class="modal-dialog">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title" id="deleteProject{{ $project->id }}Label">Projekt löschen</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    Soll das Projekt <strong>{{ $project->name }}</strong> wirklich gelöscht werden?
-                                                </div>
-                                                <div class="modal-footer">
-                                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
-                                                    <form method="POST" action="{{ route('projects.destroy', $project->id) }}" class="d-inline">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit" class="btn btn-danger">Löschen</button>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    @component('components.delete-modal', [
+                                        'modalId' => 'deleteProject' . $project->id,
+                                        'title' => 'Projekt löschen',
+                                        'message' => 'Soll das Projekt <strong>' . e($project->name) . '</strong> wirklich gelöscht werden?',
+                                        'actionRoute' => route('projects.destroy', $project->id),
+                                    ])
+                                    @endcomponent
                                 </td>
                             @endauth
                         </tr>

--- a/resources/views/user_management.blade.php
+++ b/resources/views/user_management.blade.php
@@ -32,27 +32,13 @@
                                 <button type="button" class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#deleteUser{{ $user->id }}">
                                     Löschen
                                 </button>
-                                <div class="modal fade" id="deleteUser{{ $user->id }}" tabindex="-1" aria-labelledby="deleteUser{{ $user->id }}Label" aria-hidden="true">
-                                    <div class="modal-dialog">
-                                        <div class="modal-content">
-                                            <div class="modal-header">
-                                                <h5 class="modal-title" id="deleteUser{{ $user->id }}Label">Account löschen</h5>
-                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
-                                            </div>
-                                            <div class="modal-body">
-                                                Soll der Account <strong>{{ $user->name }}</strong> wirklich gelöscht werden?
-                                            </div>
-                                            <div class="modal-footer">
-                                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
-                                                <form method="POST" action="{{ route('user-management.destroy', $user->id) }}" class="d-inline">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="btn btn-danger">Löschen</button>
-                                                </form>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
+                                @component('components.delete-modal', [
+                                    'modalId' => 'deleteUser' . $user->id,
+                                    'title' => 'Account löschen',
+                                    'message' => 'Soll der Account <strong>' . e($user->name) . '</strong> wirklich gelöscht werden?',
+                                    'actionRoute' => route('user-management.destroy', $user->id),
+                                ])
+                                @endcomponent
                             @endif
                         </td>
                     </tr>

--- a/resources/views/venues/index.blade.php
+++ b/resources/views/venues/index.blade.php
@@ -45,27 +45,13 @@
                                     <button type='button' class='btn btn-danger btn-sm' data-bs-toggle='modal' data-bs-target='#deleteVenue{{ $venue->id }}'>
                                         Löschen
                                     </button>
-                                    <div class='modal fade' id='deleteVenue{{ $venue->id }}' tabindex='-1' aria-labelledby='deleteVenue{{ $venue->id }}Label' aria-hidden='true'>
-                                        <div class='modal-dialog'>
-                                            <div class='modal-content'>
-                                                <div class='modal-header'>
-                                                    <h5 class='modal-title' id='deleteVenue{{ $venue->id }}Label'>Ort löschen</h5>
-                                                    <button type='button' class='btn-close' data-bs-dismiss='modal' aria-label='Schließen'></button>
-                                                </div>
-                                                <div class='modal-body'>
-                                                    Soll der Ort <strong>{{ $venue->name }}</strong> wirklich gelöscht werden?
-                                                </div>
-                                                <div class='modal-footer'>
-                                                    <button type='button' class='btn btn-secondary' data-bs-dismiss='modal'>Abbrechen</button>
-                                                    <form method='POST' action='{{ route('venues.destroy', $venue->id) }}' class='d-inline'>
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type='submit' class='btn btn-danger'>Löschen</button>
-                                                    </form>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    @component('components.delete-modal', [
+                                        'modalId' => 'deleteVenue' . $venue->id,
+                                        'title' => 'Ort löschen',
+                                        'message' => 'Soll der Ort <strong>' . e($venue->name) . '</strong> wirklich gelöscht werden?',
+                                        'actionRoute' => route('venues.destroy', $venue->id),
+                                    ])
+                                    @endcomponent
                                 </td>
                             @endauth
                         </tr>


### PR DESCRIPTION
This pull request refactors the delete confirmation modal implementation across multiple index views by introducing a reusable Blade component. Instead of duplicating modal markup for each entity (like materials, devices, projects, etc.), the views now use the new `delete-modal` component, which improves maintainability and consistency.

## Changes & Rationale
### Componentization and Code Reuse
* Added a new reusable Blade component `resources/views/components/delete-modal.blade.php` to encapsulate the delete confirmation modal logic and markup.

### Refactoring of Index Views
* Replaced inline modal markup with the new `delete-modal` component in the following index views:
  - `resources/views/materials/index.blade.php` for both parent and child materials. [[1]](diffhunk://#diff-766d84408ac5af852ec2a37a1841aad07bd014fd15378d941b96365f063ffac7L31-R37) [[2]](diffhunk://#diff-766d84408ac5af852ec2a37a1841aad07bd014fd15378d941b96365f063ffac7L66-R57)
  - `resources/views/artifacts/index.blade.php`.
  - `resources/views/devices/index.blade.php`.
  - `resources/views/institutions/index.blade.php`.
  - `resources/views/persons/index.blade.php`.
  - `resources/views/processes/index.blade.php`.
  - `resources/views/projects/index.blade.php`.

This change makes the codebase easier to maintain and update, since any future changes to the modal's appearance or behavior can be made in one place.

## Related Issues
<!-- Example: Closes #123, Fixes #456 -->

## Definition of Done Checklist

- [x] User story requirements met
- [x] Documentation updated
- [x] New code covered by unit tests
- [x] All unit tests pass locally
- [x] Manually tested
- [x] Works on desktop devices
- [x] Works on mobile devices

## Laravel-Specific Changes

- [ ] Migrations
- [ ] Models
- [x] Views
- [ ] Routes
- [ ] Seeders
- [ ] Config
- [ ] Artisan commands

## Infrastructure & Tooling Changes

- [ ] PHP dependencies
- [ ] Node.js dependencies
- [ ] Tooling/scripts
- [ ] CI/CD workflows
- [ ] Repository meta/templates

## Additional Notes
<!-- Add any extra context for reviewers and contributors -->
