### PR TITLE
Chore: More reusable Blade components

### DIFF
--- a/app/View/Components/Form/Input.php
+++ b/app/View/Components/Form/Input.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\View\Components\Form;
+
+use Illuminate\View\Component;
+
+class Input extends Component
+{
+    public function __construct(
+        public string $name,
+        public string $label,
+        public string $type = 'text',
+        public ?string $value = null,
+        public ?string $hint = null,
+        public ?string $placeholder = null,
+        public bool $required = false,
+        public ?string $step = null,
+        public ?string $min = null,
+        public ?string $max = null,
+    ) {
+        $this->value = $value ?? old($name);
+    }
+
+    public function render()
+    {
+        return view('components.form.input');
+    }
+}

--- a/app/View/Components/Form/Select.php
+++ b/app/View/Components/Form/Select.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\View\Components\Form;
+
+use Illuminate\Support\Collection;
+use Illuminate\View\Component;
+
+class Select extends Component
+{
+    public function __construct(
+        public string $name,
+        public string $label,
+        public Collection|array $options,
+        public ?string $value = null,
+        public ?string $hint = null,
+        public ?string $placeholder = null,
+        public bool $required = false,
+        public string $optionValue = 'id',
+        public string $optionLabel = 'name',
+    ) {
+        $this->value = $value ?? old($name);
+    }
+
+    public function render()
+    {
+        return view('components.form.select');
+    }
+}

--- a/app/View/Components/Form/Textarea.php
+++ b/app/View/Components/Form/Textarea.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\View\Components\Form;
+
+use Illuminate\View\Component;
+
+class Textarea extends Component
+{
+    public function __construct(
+        public string $name,
+        public string $label,
+        public ?string $value = null,
+        public ?string $hint = null,
+        public ?string $placeholder = null,
+        public bool $required = false,
+        public int $rows = 3,
+    ) {
+        $this->value = $value ?? old($name);
+    }
+
+    public function render()
+    {
+        return view('components.form.textarea');
+    }
+}

--- a/resources/views/artifacts/show.blade.php
+++ b/resources/views/artifacts/show.blade.php
@@ -16,68 +16,51 @@
             <p class="lead text-muted mb-0">Inventarnummer: {{ $artifact->inventory_number ?? '–' }}</p>
         </header>
 
-        <section class="mb-5" aria-labelledby="artifact-overview-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary">
-                    <h2 id="artifact-overview-title" class="h4 mb-0">Überblick</h2>
-                </div>
-                <div class="card-body">
-                    <dl class="row g-3 mb-0">
-                        <dt class="col-md-3">Standort</dt>
-                        <dd class="col-md-9">
-                            @if ($artifact->location)
-                                <a href="{{ route('locations.show', $artifact->location) }}">{{ $artifact->location->name }}</a>
-                                <span class="text-muted">{{ $artifact->location->venue?->name }}</span>
-                            @else
-                                <span class="text-muted">Kein Standort hinterlegt.</span>
-                            @endif
-                        </dd>
-
-                        <dt class="col-md-3">Ort</dt>
-                        <dd class="col-md-9">{{ $artifact->location?->venue?->name ?? '–' }}</dd>
-                    </dl>
-                </div>
-            </div>
-        </section>
-
-        <section aria-labelledby="artifact-sample-surfaces-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary d-flex align-items-center justify-content-between">
-                    <h2 id="artifact-sample-surfaces-title" class="h4 mb-0">Probenflächen</h2>
-                    <span class="badge text-bg-light">{{ $artifact->sampleSurfaces->count() }}</span>
-                </div>
-                <div class="card-body p-0">
-                    @if ($artifact->sampleSurfaces->isEmpty())
-                        <p class="px-4 py-3 mb-0 text-muted">Es wurden keine Probenflächen dokumentiert.</p>
+        <x-card.section id="artifact-overview-title" title="Überblick">
+            <dl class="row g-3 mb-0">
+                <x-card.data-row label="Standort" dt-class="col-md-3" dd-class="col-md-9">
+                    @if ($artifact->location)
+                        <a href="{{ route('locations.show', $artifact->location) }}">{{ $artifact->location->name }}</a>
+                        <span class="text-muted">{{ $artifact->location->venue?->name }}</span>
                     @else
-                        <div class="table-responsive">
-                            <table class="table table-hover mb-0 align-middle">
-                                <caption class="visually-hidden">Probenflächen des Artefakts</caption>
-                                <thead class="table-light">
-                                    <tr>
-                                        <th scope="col">Name</th>
-                                        <th scope="col">Teilflächen</th>
-                                        <th scope="col" class="text-end">Details</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @foreach ($artifact->sampleSurfaces as $surface)
-                                        <tr>
-                                            <th scope="row">{{ $surface->name }}</th>
-                                            <td>{{ $surface->partialSurfaces->count() }}</td>
-                                            <td class="text-end">
-                                                <a class="btn btn-outline-secondary btn-sm" href="{{ route('sample_surfaces.show', $surface) }}">
-                                                    Probenfläche ansehen
-                                                </a>
-                                            </td>
-                                        </tr>
-                                    @endforeach
-                                </tbody>
-                            </table>
-                        </div>
+                        <span class="text-muted">Kein Standort hinterlegt.</span>
                     @endif
+                </x-card.data-row>
+
+                <x-card.data-row label="Ort" :value="$artifact->location?->venue?->name" dt-class="col-md-3" dd-class="col-md-9" />
+            </dl>
+        </x-card.section>
+
+        <x-card.section id="artifact-sample-surfaces-title" title="Probenflächen" :count="$artifact->sampleSurfaces->count()" class="p-0">
+            @if ($artifact->sampleSurfaces->isEmpty())
+                <p class="px-4 py-3 mb-0 text-muted">Es wurden keine Probenflächen dokumentiert.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 align-middle">
+                        <caption class="visually-hidden">Probenflächen des Artefakts</caption>
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Name</th>
+                                <th scope="col">Teilflächen</th>
+                                <th scope="col" class="text-end">Details</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($artifact->sampleSurfaces as $surface)
+                                <tr>
+                                    <th scope="row">{{ $surface->name }}</th>
+                                    <td>{{ $surface->partialSurfaces->count() }}</td>
+                                    <td class="text-end">
+                                        <a class="btn btn-outline-secondary btn-sm" href="{{ route('sample_surfaces.show', $surface) }}">
+                                            Probenfläche ansehen
+                                        </a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
                 </div>
-            </div>
-        </section>
+            @endif
+        </x-card.section>
     </div>
 @endsection

--- a/resources/views/components/card/data-row.blade.php
+++ b/resources/views/components/card/data-row.blade.php
@@ -1,0 +1,16 @@
+@props([
+    'label',
+    'value' => null,
+    'fallback' => '–',
+    'dtClass' => 'col-lg-3',
+    'ddClass' => 'col-lg-9',
+])
+
+<dt class="{{ $dtClass }}">{{ $label }}</dt>
+<dd class="{{ $ddClass }}">
+    @if($slot->isNotEmpty())
+        {{ $slot }}
+    @else
+        {{ $value ?? $fallback }}
+    @endif
+</dd>

--- a/resources/views/components/card/form.blade.php
+++ b/resources/views/components/card/form.blade.php
@@ -1,0 +1,19 @@
+@props([
+    'title',
+    'width' => 'md-10',
+])
+
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-{{ $width }}">
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="mb-0">{{ $title }}</h4>
+                </div>
+                <div class="card-body">
+                    {{ $slot }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/components/card/section.blade.php
+++ b/resources/views/components/card/section.blade.php
@@ -1,0 +1,23 @@
+@props([
+    'id' => null,
+    'title',
+    'count' => null,
+])
+
+@php
+    $sectionId = $id ?? Str::slug($title) . '-title';
+@endphp
+
+<section class="mb-5" aria-labelledby="{{ $sectionId }}">
+    <div class="card shadow-sm h-100">
+        <div class="card-header bg-body-tertiary d-flex align-items-center justify-content-between">
+            <h2 id="{{ $sectionId }}" class="h4 mb-0">{{ $title }}</h2>
+            @if(!is_null($count))
+                <span class="badge text-bg-light">{{ $count }}</span>
+            @endif
+        </div>
+        <div {{ $attributes->merge(['class' => 'card-body']) }}>
+            {{ $slot }}
+        </div>
+    </div>
+</section>

--- a/resources/views/components/form/alerts.blade.php
+++ b/resources/views/components/form/alerts.blade.php
@@ -1,0 +1,33 @@
+@props(['showRequiredHint' => false])
+
+{{-- Validation Errors --}}
+@if ($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+
+{{-- Session Error --}}
+@if (session('error'))
+    <div class="alert alert-danger">
+        {{ session('error') }}
+    </div>
+@endif
+
+{{-- Session Success --}}
+@if (session('success'))
+    <div class="alert alert-success">
+        {{ session('success') }}
+    </div>
+@endif
+
+{{-- Optional: Required Fields Hint --}}
+@if ($showRequiredHint)
+    <p class="text-muted mb-3">
+        Pflichtfelder sind mit <span class="text-danger">*</span> gekennzeichnet.
+    </p>
+@endif

--- a/resources/views/components/form/input.blade.php
+++ b/resources/views/components/form/input.blade.php
@@ -1,0 +1,43 @@
+@props([
+    'name',
+    'label',
+    'type' => 'text',
+    'value' => null,
+    'hint' => null,
+    'placeholder' => null,
+    'required' => false,
+    'step' => null,
+    'min' => null,
+    'max' => null,
+])
+
+<div class="form-group mb-3">
+    <label for="{{ $name }}" class="form-label">
+        {{ $label }}
+        @if($required)
+            <span class="text-danger">*</span>
+        @endif
+    </label>
+    
+    <input 
+        type="{{ $type }}"
+        class="form-control @error($name) is-invalid @enderror"
+        id="{{ $name }}"
+        name="{{ $name }}"
+        value="{{ $value }}"
+        @if($placeholder) placeholder="{{ $placeholder }}" @endif
+        @if($step) step="{{ $step }}" @endif
+        @if($min) min="{{ $min }}" @endif
+        @if($max) max="{{ $max }}" @endif
+        @if($required) required @endif
+        {{ $attributes }}
+    >
+    
+    @if($hint)
+        <div class="form-text">{{ $hint }}</div>
+    @endif
+    
+    @error($name)
+        <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+</div>

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -1,0 +1,56 @@
+@props([
+    'name',
+    'label',
+    'options',
+    'value' => null,
+    'hint' => null,
+    'placeholder' => 'Bitte auswählen',
+    'required' => false,
+    'optionValue' => 'id',
+    'optionLabel' => 'name',
+])
+
+<div class="form-group mb-3">
+    <label for="{{ $name }}" class="form-label">
+        {{ $label }}
+        @if($required)
+            <span class="text-danger">*</span>
+        @endif
+    </label>
+    
+    <select 
+        class="form-control @error($name) is-invalid @enderror"
+        id="{{ $name }}"
+        name="{{ $name }}"
+        @if($required) required @endif
+        {{ $attributes }}
+    >
+        @if($placeholder)
+            <option value="">{{ $placeholder }}</option>
+        @endif
+        
+        @foreach($options as $option)
+            @if(is_array($option) || is_object($option))
+                <option 
+                    value="{{ data_get($option, $optionValue) }}" 
+                    @selected($value == data_get($option, $optionValue))
+                >
+                    {{ data_get($option, $optionLabel) }}
+                </option>
+            @else
+                {{-- Simple key => value array --}}
+                <option value="{{ $loop->index }}" @selected($value == $loop->index)>
+                    {{ $option }}
+                </option>
+            @endif
+        @endforeach
+    </select>
+    
+    @if($hint)
+        <div class="form-text">{!! $hint !!}</div>
+    @endif
+    
+    @error($name)
+        <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+</div>

--- a/resources/views/components/form/textarea.blade.php
+++ b/resources/views/components/form/textarea.blade.php
@@ -1,0 +1,36 @@
+@props([
+    'name',
+    'label',
+    'value' => null,
+    'hint' => null,
+    'placeholder' => null,
+    'required' => false,
+    'rows' => 3,
+])
+
+<div class="form-group mb-3">
+    <label for="{{ $name }}" class="form-label">
+        {{ $label }}
+        @if($required)
+            <span class="text-danger">*</span>
+        @endif
+    </label>
+    
+    <textarea 
+        class="form-control @error($name) is-invalid @enderror"
+        id="{{ $name }}"
+        name="{{ $name }}"
+        rows="{{ $rows }}"
+        @if($placeholder) placeholder="{{ $placeholder }}" @endif
+        @if($required) required @endif
+        {{ $attributes }}
+    >{{ $value }}</textarea>
+    
+    @if($hint)
+        <div class="form-text">{{ $hint }}</div>
+    @endif
+    
+    @error($name)
+        <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+</div>

--- a/resources/views/devices/show.blade.php
+++ b/resources/views/devices/show.blade.php
@@ -24,177 +24,136 @@
             </p>
         </header>
 
-        <section class="mb-5" aria-labelledby="device-overview-title">
-            <div class="card shadow-sm h-100">
-                <div class="card-header bg-body-tertiary">
-                    <h2 id="device-overview-title" class="h4 mb-0">Überblick</h2>
+        <x-card.section id="device-overview-title" title="Überblick" class="h-100">
+            <dl class="row g-3 mb-0">
+                <x-card.data-row label="Gerätenummer" :value="$device->id" dt-class="col-lg-3" dd-class="col-lg-9" />
+                <x-card.data-row label="Baujahr" :value="$device->year" dt-class="col-lg-3" dd-class="col-lg-9" />
+                <x-card.data-row label="Bauart" :value="$device->build_type" dt-class="col-lg-3" dd-class="col-lg-9" />
+                <x-card.data-row label="Strahltyp" :value="$device->beam_type_name" dt-class="col-lg-3" dd-class="col-lg-9" />
+
+                <x-card.data-row label="Max. Leistung" dt-class="col-lg-3" dd-class="col-lg-9">
+                    {{ $device->max_output ? number_format($device->max_output, 2, ',', '.') . ' W' : '–' }}
+                </x-card.data-row>
+
+                <x-card.data-row label="Kühlung" :value="$device->cooling_type" dt-class="col-lg-3" dd-class="col-lg-9" />
+
+                <x-card.data-row label="Automatisierung" dt-class="col-lg-3" dd-class="col-lg-9">
+                    <span class="badge {{ $device->automation ? 'bg-success-subtle text-success-emphasis' : 'bg-secondary-subtle text-secondary-emphasis' }}">
+                        {{ $device->automation ? 'Automatisiert' : 'Manuell' }}
+                    </span>
+                </x-card.data-row>
+
+                <x-card.data-row label="Zuletzt bearbeitet durch" :value="$device->lastEditor?->name" dt-class="col-lg-3" dd-class="col-lg-9" />
+            </dl>
+        </x-card.section>
+
+        <x-card.section id="device-specifications-title" title="Technische Spezifikationen" class="h-100">
+            <div class="row gy-4">
+                <div class="col-md-6">
+                    <h3 class="h5">Optik</h3>
+                    <ul class="list-unstyled mb-0" aria-label="Optische Eigenschaften">
+                        <li><strong>Wellenlänge:</strong> {{ $device->wavelength ? $device->wavelength . ' nm' : '–' }}</li>
+                        <li><strong>Spot-Größe:</strong>
+                            @if ($device->min_spot_size || $device->max_spot_size)
+                                {{ $device->min_spot_size ?? '–' }} – {{ $device->max_spot_size ?? '–' }} mm
+                            @else
+                                –
+                            @endif
+                        </li>
+                        <li><strong>Scanfeld:</strong>
+                            @if ($device->min_scan_width || $device->max_scan_width)
+                                {{ $device->min_scan_width ?? '–' }} – {{ $device->max_scan_width ?? '–' }} mm
+                            @else
+                                –
+                            @endif
+                        </li>
+                    </ul>
                 </div>
-                <div class="card-body">
-                    <dl class="row g-3 mb-0">
-                        <dt class="col-lg-3">Gerätenummer</dt>
-                        <dd class="col-lg-9">{{ $device->id }}</dd>
-
-                        <dt class="col-lg-3">Baujahr</dt>
-                        <dd class="col-lg-9">{{ $device->year ?? '–' }}</dd>
-
-                        <dt class="col-lg-3">Bauart</dt>
-                        <dd class="col-lg-9">{{ $device->build_type }}</dd>
-
-                        <dt class="col-lg-3">Strahltyp</dt>
-                        <dd class="col-lg-9">{{ $device->beam_type_name }}</dd>
-
-                        <dt class="col-lg-3">Max. Leistung</dt>
-                        <dd class="col-lg-9">
-                            {{ $device->max_output ? number_format($device->max_output, 2, ',', '.') . ' W' : '–' }}
-                        </dd>
-
-                        <dt class="col-lg-3">Kühlung</dt>
-                        <dd class="col-lg-9">{{ $device->cooling_type ?? '–' }}</dd>
-
-                        <dt class="col-lg-3">Automatisierung</dt>
-                        <dd class="col-lg-9">
-                            <span class="badge {{ $device->automation ? 'bg-success-subtle text-success-emphasis' : 'bg-secondary-subtle text-secondary-emphasis' }}">
-                                {{ $device->automation ? 'Automatisiert' : 'Manuell' }}
-                            </span>
-                        </dd>
-
-                        <dt class="col-lg-3">Zuletzt bearbeitet durch</dt>
-                        <dd class="col-lg-9">{{ $device->lastEditor?->name ?? '–' }}</dd>
-                    </dl>
-                </div>
-            </div>
-        </section>
-
-        <section class="mb-5" aria-labelledby="device-specifications-title">
-            <div class="card shadow-sm h-100">
-                <div class="card-header bg-body-tertiary">
-                    <h2 id="device-specifications-title" class="h4 mb-0">Technische Spezifikationen</h2>
-                </div>
-                <div class="card-body">
-                    <div class="row gy-4">
-                        <div class="col-md-6">
-                            <h3 class="h5">Optik</h3>
-                            <ul class="list-unstyled mb-0" aria-label="Optische Eigenschaften">
-                                <li><strong>Wellenlänge:</strong> {{ $device->wavelength ? $device->wavelength . ' nm' : '–' }}</li>
-                                <li><strong>Spot-Größe:</strong>
-                                    @if ($device->min_spot_size || $device->max_spot_size)
-                                        {{ $device->min_spot_size ?? '–' }} – {{ $device->max_spot_size ?? '–' }} mm
-                                    @else
-                                        –
-                                    @endif
-                                </li>
-                                <li><strong>Scanfeld:</strong>
-                                    @if ($device->min_scan_width || $device->max_scan_width)
-                                        {{ $device->min_scan_width ?? '–' }} – {{ $device->max_scan_width ?? '–' }} mm
-                                    @else
-                                        –
-                                    @endif
-                                </li>
-                            </ul>
-                        </div>
-                        <div class="col-md-6">
-                            <h3 class="h5">Mechanik</h3>
-                            <ul class="list-unstyled mb-0" aria-label="Mechanische Eigenschaften">
-                                <li><strong>Abmessungen (H × B × T):</strong>
-                                    @if ($device->height || $device->width || $device->depth)
-                                        {{ $device->height ?? '–' }} × {{ $device->width ?? '–' }} × {{ $device->depth ?? '–' }} mm
-                                    @else
-                                        –
-                                    @endif
-                                </li>
-                                <li><strong>Gewicht:</strong>
-                                    {{ $device->weight ? number_format((float) $device->weight, 2, ',', '.') . ' kg' : '–' }}
-                                </li>
-                                <li><strong>Faserlänge:</strong>
-                                    {{ $device->fiber_length ? number_format((float) $device->fiber_length, 2, ',', '.') . ' m' : '–' }}
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
+                <div class="col-md-6">
+                    <h3 class="h5">Mechanik</h3>
+                    <ul class="list-unstyled mb-0" aria-label="Mechanische Eigenschaften">
+                        <li><strong>Abmessungen (H × B × T):</strong>
+                            @if ($device->height || $device->width || $device->depth)
+                                {{ $device->height ?? '–' }} × {{ $device->width ?? '–' }} × {{ $device->depth ?? '–' }} mm
+                            @else
+                                –
+                            @endif
+                        </li>
+                        <li><strong>Gewicht:</strong>
+                            {{ $device->weight ? number_format((float) $device->weight, 2, ',', '.') . ' kg' : '–' }}
+                        </li>
+                        <li><strong>Faserlänge:</strong>
+                            {{ $device->fiber_length ? number_format((float) $device->fiber_length, 2, ',', '.') . ' m' : '–' }}
+                        </li>
+                    </ul>
                 </div>
             </div>
-        </section>
+        </x-card.section>
 
-        <section class="mb-5" aria-labelledby="device-lenses-title">
-            <div class="card shadow-sm h-100">
-                <div class="card-header bg-body-tertiary d-flex align-items-center justify-content-between">
-                    <h2 id="device-lenses-title" class="h4 mb-0">Verfügbare Linsen</h2>
-                    <span class="badge text-bg-light">{{ $device->lenses->count() }}</span>
-                </div>
-                <div class="card-body">
-                    @if ($device->lenses->isEmpty())
-                        <p class="mb-0 text-muted">Für dieses Gerät wurden noch keine Linsen dokumentiert.</p>
-                    @else
-                        <ul class="list-group list-group-flush">
-                            @foreach ($device->lenses as $lens)
-                                <li class="list-group-item d-flex flex-column flex-md-row gap-2 justify-content-between">
-                                    <div>
-                                        <strong>Linse #{{ $lens->id }}</strong>
-                                        <p class="mb-0 text-muted">Größe: {{ $lens->size }} mm</p>
-                                    </div>
-                                    <div class="text-md-end">
-                                        <span class="badge text-bg-primary">Konfigurationen: {{ $lens->configurations->count() }}</span>
-                                    </div>
-                                </li>
+        <x-card.section id="device-lenses-title" title="Verfügbare Linsen" :count="$device->lenses->count()" class="h-100">
+            @if ($device->lenses->isEmpty())
+                <p class="mb-0 text-muted">Für dieses Gerät wurden noch keine Linsen dokumentiert.</p>
+            @else
+                <ul class="list-group list-group-flush">
+                    @foreach ($device->lenses as $lens)
+                        <li class="list-group-item d-flex flex-column flex-md-row gap-2 justify-content-between">
+                            <div>
+                                <strong>Linse #{{ $lens->id }}</strong>
+                                <p class="mb-0 text-muted">Größe: {{ $lens->size }} mm</p>
+                            </div>
+                            <div class="text-md-end">
+                                <span class="badge text-bg-primary">Konfigurationen: {{ $lens->configurations->count() }}</span>
+                            </div>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </x-card.section>
+
+        <x-card.section id="device-processes-title" title="Durchgeführte Prozesse" :count="$device->processes->count()" class="p-0">
+            @if ($device->processes->isEmpty())
+                <p class="px-4 py-3 mb-0 text-muted">Zu diesem Gerät wurden noch keine Prozesse dokumentiert.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Prozess-ID</th>
+                                <th scope="col">Teilfläche</th>
+                                <th scope="col">Artefakt</th>
+                                <th scope="col">Ort</th>
+                                <th scope="col" class="text-end">Details</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($device->processes as $process)
+                                @php($partial = $process->partialSurface)
+                                <tr>
+                                    <th scope="row">#{{ $process->id }}</th>
+                                    <td>{{ $partial?->identifier ?? '–' }}</td>
+                                    <td>{{ $partial?->sampleSurface?->artifact?->name ?? '–' }}</td>
+                                    <td>
+                                        {{ $partial?->sampleSurface?->artifact?->location?->venue?->name ?? '–' }}<br>
+                                        <span class="text-muted small">
+                                            {{ $partial?->sampleSurface?->artifact?->location?->venue?->city?->name ?? '' }}
+                                        </span>
+                                    </td>
+                                    <td class="text-end">
+                                        @auth
+                                            <a class="btn btn-outline-secondary btn-sm"
+                                                href="{{ route('processes.show', $process) }}">
+                                                Details anzeigen
+                                            </a>
+                                        @else
+                                            <span class="text-muted small">Anmeldung erforderlich</span>
+                                        @endauth
+                                    </td>
+                                </tr>
                             @endforeach
-                        </ul>
-                    @endif
+                        </tbody>
+                    </table>
                 </div>
-            </div>
-        </section>
-
-        <section aria-labelledby="device-processes-title" class="mb-5">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary d-flex align-items-center justify-content-between">
-                    <h2 id="device-processes-title" class="h4 mb-0">Durchgeführte Prozesse</h2>
-                    <span class="badge text-bg-light">{{ $device->processes->count() }}</span>
-                </div>
-                <div class="card-body p-0">
-                    @if ($device->processes->isEmpty())
-                        <p class="px-4 py-3 mb-0 text-muted">Zu diesem Gerät wurden noch keine Prozesse dokumentiert.</p>
-                    @else
-                        <div class="table-responsive">
-                            <table class="table table-hover mb-0 align-middle">
-                                <thead class="table-light">
-                                    <tr>
-                                        <th scope="col">Prozess-ID</th>
-                                        <th scope="col">Teilfläche</th>
-                                        <th scope="col">Artefakt</th>
-                                        <th scope="col">Ort</th>
-                                        <th scope="col" class="text-end">Details</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @foreach ($device->processes as $process)
-                                        @php($partial = $process->partialSurface)
-                                        <tr>
-                                            <th scope="row">#{{ $process->id }}</th>
-                                            <td>{{ $partial?->identifier ?? '–' }}</td>
-                                            <td>{{ $partial?->sampleSurface?->artifact?->name ?? '–' }}</td>
-                                            <td>
-                                                {{ $partial?->sampleSurface?->artifact?->location?->venue?->name ?? '–' }}<br>
-                                                <span class="text-muted small">
-                                                    {{ $partial?->sampleSurface?->artifact?->location?->venue?->city?->name ?? '' }}
-                                                </span>
-                                            </td>
-                                            <td class="text-end">
-                                                @auth
-                                                    <a class="btn btn-outline-secondary btn-sm"
-                                                        href="{{ route('processes.show', $process) }}">
-                                                        Details anzeigen
-                                                    </a>
-                                                @else
-                                                    <span class="text-muted small">Anmeldung erforderlich</span>
-                                                @endauth
-                                            </td>
-                                        </tr>
-                                    @endforeach
-                                </tbody>
-                            </table>
-                        </div>
-                    @endif
-                </div>
-            </div>
-        </section>
+            @endif
+        </x-card.section>
     </div>
 @endsection

--- a/resources/views/inputform_artifact.blade.php
+++ b/resources/views/inputform_artifact.blade.php
@@ -17,49 +17,31 @@
 
                             <x-form.alerts :showRequiredHint="true" />
 
-                            <div class="mb-5">
-                                <label for="artifact_name" class="form-label">Objektname <span
-                                        class="text-danger">*</span></label>
-                                <input type="text" class="form-control" id="artifact_name" name="artifact_name"
-                                    value="{{ old('artifact_name') }}" required placeholder="Legen Sie den Name eines neuen Objekts an." />
-                                @error('artifact_name')
-                                    <div class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </div>
-                                @enderror
-                            </div>
+                            <x-form.input
+                                name="artifact_name"
+                                label="Objektname"
+                                placeholder="Legen Sie den Name eines neuen Objekts an."
+                                :required="true"
+                            />
 
-                            <div class="mb-5">
-                                <label for="artifact_inventory_number" class="form-label">Inventarnummer</label>
-                                <input type="text" class="form-control" id="artifact_inventory_number" name="artifact_inventory_number"
-                                    value="{{ old('artifact_inventory_number') }}" placeholder="Geben Sie hier die Inventarnummer an." />
-                                @error('artifact_inventory_number')
-                                    <div class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </div>
-                                @enderror
-                            </div>
+                            <x-form.input
+                                name="artifact_inventory_number"
+                                label="Inventarnummer"
+                                placeholder="Geben Sie hier die Inventarnummer an."
+                            />
 
-                            <div class="mb-5">
-                                <label for="artifact_location_id" class="form-label">Standort <span class="text-danger">*</span></label>
-                                <select class="form-select" id="artifact_location_id" name="artifact_location_id" required>
-                                    <option value="">Wählen Sie einen Standort aus.</option>
-                                    @foreach($locations as $location)
-                                        <option value="{{ $location->id }}" {{ old('artifact_location_id') == $location->id ? 'selected' : '' }}>
-                                            {{ $location->name }}
-                                        </option>
-                                    @endforeach
-                                </select>
-                                <div class="form-text">
+                            <x-form.select
+                                name="artifact_location_id"
+                                label="Standort"
+                                :options="$locations"
+                                placeholder="Wählen Sie einen Standort aus."
+                                :required="true"
+                            >
+                                <x-slot:hint>
                                     Kein passender Standort verfügbar?
                                     <a href="{{ route('locations.create') }}" class="link-primary">Legen Sie einen neuen Standort an.</a>
-                                </div>
-                                @error('artifact_location_id')
-                                    <div class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </div>
-                                @enderror
-                            </div>
+                                </x-slot:hint>
+                            </x-form.select>
 
                             <div class="d-flex justify-content-end gap-2">
                                 <button type="submit" class="btn btn-primary">Speichern</button>

--- a/resources/views/inputform_artifact.blade.php
+++ b/resources/views/inputform_artifact.blade.php
@@ -14,29 +14,8 @@
                     <div class="card-body">
                         <form method="POST" action="{{ route('inputform_artifact.store') }}">
                             @csrf
-                            @if ($errors->any())
-                                <div class="alert alert-danger">
-                                    <ul class="mb-0">
-                                        @foreach ($errors->all() as $error)
-                                            <li>{{ $error }}</li>
-                                        @endforeach
-                                    </ul>
-                                </div>
-                            @endif
 
-                            @if(session('error'))
-                                <div class="alert alert-danger">
-                                    {{ session('error') }}
-                                </div>
-                            @endif
-
-                            @if(session('success'))
-                                <div class="alert alert-success">
-                                    {{ session('success') }}
-                                </div>
-                            @endif
-
-                            <p>Pflichtfelder sind mit <span class="text-danger">*</span> gekennzeichnet.</p>
+                            <x-form.alerts :showRequiredHint="true" />
 
                             <div class="mb-5">
                                 <label for="artifact_name" class="form-label">Objektname <span

--- a/resources/views/inputform_device.blade.php
+++ b/resources/views/inputform_device.blade.php
@@ -10,23 +10,7 @@
                         <h4 class="mb-0">Neues Lasergerät hinzufügen</h4>
                     </div>
                     <div class="card-body">
-                        {{-- Display validation errors --}}
-                        @if ($errors->any())
-                            <div class="alert alert-danger">
-                                <ul class="mb-0">
-                                    @foreach ($errors->all() as $error)
-                                        <li>{{ $error }}</li>
-                                    @endforeach
-                                </ul>
-                            </div>
-                        @endif
-
-                        {{-- Display success message --}}
-                        @if (session('success'))
-                            <div class="alert alert-success">
-                                {{ session('success') }}
-                            </div>
-                        @endif
+                        <x-form.alerts />
 
                         <form action="{{ route('inputform.store') }}" method="post">
                             @csrf

--- a/resources/views/inputform_image.blade.php
+++ b/resources/views/inputform_image.blade.php
@@ -9,23 +9,7 @@
                         <h4 class="mb-0">Bild hochladen</h4>
                     </div>
                     <div class="card-body">
-                        {{-- Display validation errors --}}
-                        @if ($errors->any())
-                            <div class="alert alert-danger">
-                                <ul class="mb-0">
-                                    @foreach ($errors->all() as $error)
-                                        <li>{{ $error }}</li>
-                                    @endforeach
-                                </ul>
-                            </div>
-                        @endif
-
-                        {{-- Display success message --}}
-                        @if (session('success'))
-                            <div class="alert alert-success">
-                                {{ session('success') }}
-                            </div>
-                        @endif
+                        <x-form.alerts />
 
                         <form action="{{ route('inputform_image.store') }}" method="post" enctype="multipart/form-data">
                             @csrf

--- a/resources/views/inputform_image.blade.php
+++ b/resources/views/inputform_image.blade.php
@@ -15,21 +15,13 @@
                             @csrf
                             <div class="row">
                                 <div class="col-md-6">
-                                    <div class="form-group mb-3">
-                                        <label for="project_id" class="form-label">Projekt *</label>
-                                        <select class="form-control @error('project_id') is-invalid @enderror"
-                                            id="project_id" name="project_id" required>
-                                            <option value="" disabled hidden>Bitte wählen Sie ein Projekt aus</option>
-                                            @foreach ($projects as $project)
-                                                <option value="{{ $project->id }}" {{ old('project_id') == $project->id ? 'selected' : '' }}>
-                                                    {{ $project->name }}
-                                                </option>
-                                            @endforeach
-                                        </select>
-                                        @error('project_id')
-                                            <div class="invalid-feedback">{{ $message }}</div>
-                                        @enderror
-                                    </div>
+                                    <x-form.select
+                                        name="project_id"
+                                        label="Projekt"
+                                        :options="$projects"
+                                        placeholder="Bitte wählen Sie ein Projekt aus"
+                                        :required="true"
+                                    />
                                     <div class="form-group mb-3">
                                         <label for="condition_id" class="form-label">Zustand</label>
                                         <select
@@ -52,42 +44,30 @@
                                             <div class="invalid-feedback">{{ __('Die ausgewählte Zustandsoption ist nicht verfügbar. Bitte wählen Sie einen anderen Wert aus.') }}</div>
                                         @enderror
                                     </div>
-                                    <div class="form-group mb-3">
-                                        <label class="form-label">Beschreibung</label>
-                                        <textarea class="form-control @error('description') is-invalid @enderror"
-                                            name="description" rows="3">{{ old('description') }}</textarea>
-                                        @error('description')
-                                            <div class="invalid-feedback">{{ $message }}</div>
-                                        @enderror
-                                        <div class="form-text">
-                                            Bitte geben Sie eine Beschreibung an.
-                                        </div>
-                                    </div>
-                                    <div class="form-group mb-3">
-                                        <label class="form-label">Alternativer Text *</label>
-                                        <textarea class="form-control @error('alt_text') is-invalid @enderror"
-                                            name="alt_text" rows="3">{{ old('alt_text') }}</textarea>
-                                        <div class="form-text">
-                                            Bitte geben Sie einen alternativen Text an.
-                                        </div>
-                                    </div>
-                                    <div class="form-group mb-3">
-                                        <label for="year_created" class="form-label">Entstehungsjahr *</label>
-                                        <input type="number" class="form-control @error('year_created') is-invalid @enderror"
-                                            id="year_created" name="year_created" value="{{ old('year_created') }}"
-                                            required>
-                                        <div class="form-text">
-                                            Bitte geben Sie das Entstehungsjahr an.
-                                        </div>
-                                    </div>
-                                    <div class="form-group mb-3">
-                                        <label for="creator" class="form-label">Urheber *</label>
-                                        <input type="text" class="form-control @error('creator') is-invalid @enderror"
-                                            id="creator" name="creator" value="{{ old('creator') }}" required>
-                                        <div class="form-text">
-                                            Bitte geben Sie den Urheber an.
-                                        </div>
-                                    </div>
+                                    <x-form.textarea
+                                        name="description"
+                                        label="Beschreibung"
+                                        hint="Bitte geben Sie eine Beschreibung an."
+                                    />
+                                    <x-form.textarea
+                                        name="alt_text"
+                                        label="Alternativer Text"
+                                        hint="Bitte geben Sie einen alternativen Text an."
+                                        :required="true"
+                                    />
+                                    <x-form.input
+                                        name="year_created"
+                                        label="Entstehungsjahr"
+                                        type="number"
+                                        hint="Bitte geben Sie das Entstehungsjahr an."
+                                        :required="true"
+                                    />
+                                    <x-form.input
+                                        name="creator"
+                                        label="Urheber"
+                                        hint="Bitte geben Sie den Urheber an."
+                                        :required="true"
+                                    />
                                     <div class="form-group mb-3">
                                         <label for="image" class="form-label">Bild auswählen *</label>
                                         <input type="file" class="form-control @error('image') is-invalid @enderror"

--- a/resources/views/inputform_institution.blade.php
+++ b/resources/views/inputform_institution.blade.php
@@ -19,36 +19,33 @@
                             @csrf
                             <div class="row">
                                 <div class="col-md-6">
-                                    <div class="form-group mb-3">
-                                        <label for="name" class="form-label">Name der Institution: <strong>*</strong></label>
-                                        <input type="text" class="form-control @error('name') is-invalid @enderror"
-                                            id="name" name="name" value="{{ old('name') }}" required>
-                                        <div class="form-text">
-                                            Bitte geben Sie eine eindeutige Bezeichnung der Institution ein.
-                                        </div>
-                                    </div>
+                                    <x-form.input
+                                        name="name"
+                                        label="Name der Institution"
+                                        hint="Bitte geben Sie eine eindeutige Bezeichnung der Institution ein."
+                                        :required="true"
+                                    />
 
-                                    <div class="form-group mb-3">
-                                        <label for="type" class="form-label">Typ: <strong>*</strong></label>
-                                        <select class="form-control @error('type') is-invalid @enderror" id="type" name="type" required>
-                                            <option value="">Bitte auswählen</option>
-                                            <option value="{{ Institution::TYPE_CLIENT}}" {{ old('type') == Institution::TYPE_CLIENT ? 'selected' : '' }}>Auftraggeber</option>
-                                            <option value="{{ Institution::TYPE_CONTRACTOR}}" {{ old('type') == Institution::TYPE_CONTRACTOR ? 'selected' : '' }}>Auftragnehmer</option>
-                                            <option value="{{ Institution::TYPE_MANUFACTURER}}" {{ old('type') == Institution::TYPE_MANUFACTURER ? 'selected' : '' }}>Hersteller</option>
-                                        </select>
-                                        <div class="form-text">
-                                            Bitte wählen Sie die passende Typenbezeichnung aus der Liste aus.
-                                        </div>
-                                    </div>
+                                    <x-form.select
+                                        name="type"
+                                        label="Typ"
+                                        :options="[
+                                            Institution::TYPE_CLIENT => 'Auftraggeber',
+                                            Institution::TYPE_CONTRACTOR => 'Auftragnehmer',
+                                            Institution::TYPE_MANUFACTURER => 'Hersteller',
+                                        ]"
+                                        placeholder="Bitte auswählen"
+                                        hint="Bitte wählen Sie die passende Typenbezeichnung aus der Liste aus."
+                                        :required="true"
+                                    />
 
-                                    <div class="form-group mb-3">
-                                        <label for="contact_information" class="form-label">Kontaktinformation: <strong>*</strong></label>
-                                        <textarea class="form-control @error('contact_information') is-invalid @enderror"
-                                            name="contact_information" rows="3" required>{{ old('contact_information') }}</textarea>
-                                        <div class="form-text">
-                                            Bitte geben Sie eine Kontaktinformation ein, wie z.B. einen Webseitenlink.
-                                        </div>
-                                    </div>
+                                    <x-form.textarea
+                                        name="contact_information"
+                                        label="Kontaktinformation"
+                                        hint="Bitte geben Sie eine Kontaktinformation ein, wie z.B. einen Webseitenlink."
+                                        :required="true"
+                                    />
+
                                     <div class="form-text mb-3">
                                         <strong>*</strong> Pflichtangabe
                                     </div>

--- a/resources/views/inputform_institution.blade.php
+++ b/resources/views/inputform_institution.blade.php
@@ -13,23 +13,7 @@
                         <h4 class="mb-0">Neue Institution hinzufügen</h4>
                     </div>
                     <div class="card-body">
-                        {{-- Display validation errors --}}
-                        @if ($errors->any())
-                            <div class="alert alert-danger">
-                                <ul class="mb-0">
-                                    @foreach ($errors->all() as $error)
-                                        <li>{{ $error }}</li>
-                                    @endforeach
-                                </ul>
-                            </div>
-                        @endif 
-
-                        {{-- Display success message --}}
-                        @if (session('success'))
-                            <div class="alert alert-success">
-                                {{ session('success') }}
-                            </div>
-                        @endif
+                        <x-form.alerts />
 
                         <form action="{{ route('inputform_institution.store') }}" method="post">
                             @csrf

--- a/resources/views/inputform_location.blade.php
+++ b/resources/views/inputform_location.blade.php
@@ -12,24 +12,7 @@
                         <p class="mb-0 text-muted">Alle Pflichtfelder sind mit einem <span class="text-danger">*</span> gekennzeichnet.</p>
                     </div>
                     <div class="card-body">
-                        @if ($errors->any())
-                            <div class="alert alert-danger" role="alert" aria-live="assertive">
-                                <h2 class="h5">Bitte überprüfen Sie Ihre Eingaben:</h2>
-                                <ul class="mb-0">
-                                    @foreach ($errors->all() as $error)
-                                        <li>{{ $error }}</li>
-                                    @endforeach
-                                </ul>
-                            </div>
-                        @endif
-
-                        @if (session('error'))
-                            <div class="alert alert-danger" role="alert">{{ session('error') }}</div>
-                        @endif
-
-                        @if (session('success'))
-                            <div class="alert alert-success" role="status">{{ session('success') }}</div>
-                        @endif
+                        <x-form.alerts />
 
                         <form method="POST" action="{{ route('locations.store') }}" novalidate>
                             @csrf

--- a/resources/views/inputform_material.blade.php
+++ b/resources/views/inputform_material.blade.php
@@ -17,38 +17,21 @@
 
                             <x-form.alerts />
 
-                            <div class="mb-5">
-                                <label for="material_parent_id" class="form-label">Übergeordnetes Material</label>
-                                <select class="form-select" id="material_parent_id" name="material_parent_id">
-                                    <option value="">-</option>
-                                    @foreach($materials as $material)
-                                        <option value="{{ $material->id }}">{{ $material->name }}</option>
-                                    @endforeach
-                                </select>
-                                <div class="form-text">
-                                    Ohne Auswahl wird das neue Material als eigenständiges Material angelegt.
-                                </div>
-                                @error('material_parent_id')
-                                    <div class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </div>
-                                @enderror
-                            </div>
+                            <x-form.select
+                                name="material_parent_id"
+                                label="Übergeordnetes Material"
+                                :options="$materials"
+                                placeholder="-"
+                                hint="Ohne Auswahl wird das neue Material als eigenständiges Material angelegt."
+                            />
 
-                            <div class="mb-5">
-                                <label for="material_name" class="form-label">Material <span
-                                        class="text-danger">*</span></label>
-                                <input type="text" class="form-control" id="material_name" name="material_name"
-                                    value="{{ old('material_name') }}" required placeholder="Materialname" />
-                                <div class="form-text">
-                                    Bitte wählen Sie ein Material aus der Liste.
-                                </div>
-                                @error('material_name')
-                                    <div class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </div>
-                                @enderror
-                            </div>
+                            <x-form.input
+                                name="material_name"
+                                label="Material"
+                                placeholder="Materialname"
+                                hint="Bitte geben Sie einen Materialnamen ein."
+                                :required="true"
+                            />
 
                             <div class="d-flex justify-content-end gap-2">
                                 <button type="submit" class="btn btn-primary">Speichern</button>

--- a/resources/views/inputform_material.blade.php
+++ b/resources/views/inputform_material.blade.php
@@ -15,17 +15,7 @@
                         <form method="POST" action="{{ route('inputform_material.store') }}">
                             @csrf
 
-                            @if(session('error'))
-                                <div class="alert alert-danger">
-                                    {{ session('error') }}
-                                </div>
-                            @endif
-
-                            @if(session('success'))
-                                <div class="alert alert-success">
-                                    {{ session('success') }}
-                                </div>
-                            @endif
+                            <x-form.alerts />
 
                             <div class="mb-5">
                                 <label for="material_parent_id" class="form-label">Übergeordnetes Material</label>

--- a/resources/views/inputform_person.blade.php
+++ b/resources/views/inputform_person.blade.php
@@ -1,47 +1,36 @@
 @extends('layouts.app')
 @section('title', $pageTitle)
 @section('content')
-    <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-md-10">
-                <div class="card">
-                    <div class="card-header">
-                        <h4 class="mb-0">Neue Person hinzufügen</h4>
-                    </div>
-                    <div class="card-body">
-                        <x-form.alerts />
+    <x-card.form title="Neue Person hinzufügen">
+        <x-form.alerts />
 
-                        <form action="{{ route('inputform_person.store') }}" method="post">
-                            @csrf
-                            <div class="row">
-                                <div class="col-md-6">
-                                    <x-form.input
-                                        name="name"
-                                        label="Name"
-                                        :required="true"
-                                    />
+        <form action="{{ route('inputform_person.store') }}" method="post">
+            @csrf
+            <div class="row">
+                <div class="col-md-6">
+                    <x-form.input
+                        name="name"
+                        label="Name"
+                        :required="true"
+                    />
 
-                                    <x-form.select
-                                        name="institution_id"
-                                        label="Institution"
-                                        :options="$institutions"
-                                        placeholder="Bitte auswählen"
-                                        :required="true"
-                                    />
+                    <x-form.select
+                        name="institution_id"
+                        label="Institution"
+                        :options="$institutions"
+                        placeholder="Bitte auswählen"
+                        :required="true"
+                    />
 
-                                    <div class="form-text mb-3">
-                                        <strong>*</strong> Pflichtangabe
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="form-group mt-4">
-                                <button type="reset" class="btn btn-secondary">Werte zurücksetzen</button>
-                                <button type="submit" class="btn btn-primary">Hinzufügen</button>
-                            </div>
-                        </form>
+                    <div class="form-text mb-3">
+                        <strong>*</strong> Pflichtangabe
                     </div>
                 </div>
             </div>
-        </div>
-    </div>
+            <div class="form-group mt-4">
+                <button type="reset" class="btn btn-secondary">Werte zurücksetzen</button>
+                <button type="submit" class="btn btn-primary">Hinzufügen</button>
+            </div>
+        </form>
+    </x-card.form>
 @endsection

--- a/resources/views/inputform_person.blade.php
+++ b/resources/views/inputform_person.blade.php
@@ -9,21 +9,7 @@
                         <h4 class="mb-0">Neue Person hinzufügen</h4>
                     </div>
                     <div class="card-body">
-                        @if ($errors->any())
-                            <div class="alert alert-danger">
-                                <ul class="mb-0">
-                                    @foreach ($errors->all() as $error)
-                                        <li>{{ $error }}</li>
-                                    @endforeach
-                                </ul>
-                            </div>
-                        @endif
-
-                        @if (session('success'))
-                            <div class="alert alert-success">
-                                {{ session('success') }}
-                            </div>
-                        @endif
+                        <x-form.alerts />
 
                         <form action="{{ route('inputform_person.store') }}" method="post">
                             @csrf

--- a/resources/views/inputform_person.blade.php
+++ b/resources/views/inputform_person.blade.php
@@ -15,20 +15,19 @@
                             @csrf
                             <div class="row">
                                 <div class="col-md-6">
-                                    <div class="form-group mb-3">
-                                        <label for="name" class="form-label">Name: <strong>*</strong></label>
-                                        <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name') }}" required>
-                                    </div>
+                                    <x-form.input
+                                        name="name"
+                                        label="Name"
+                                        :required="true"
+                                    />
 
-                                    <div class="form-group mb-3">
-                                        <label for="institution_id" class="form-label">Institution: <strong>*</strong></label>
-                                        <select class="form-control @error('institution_id') is-invalid @enderror" id="institution_id" name="institution_id" required>
-                                            <option value="">Bitte auswählen</option>
-                                            @foreach($institutions as $institution)
-                                                <option value="{{ $institution->id }}" @selected(old('institution_id') == $institution->id)>{{ $institution->name }}</option>
-                                            @endforeach
-                                        </select>
-                                    </div>
+                                    <x-form.select
+                                        name="institution_id"
+                                        label="Institution"
+                                        :options="$institutions"
+                                        placeholder="Bitte auswählen"
+                                        :required="true"
+                                    />
 
                                     <div class="form-text mb-3">
                                         <strong>*</strong> Pflichtangabe

--- a/resources/views/inputform_project.blade.php
+++ b/resources/views/inputform_project.blade.php
@@ -17,80 +17,61 @@
 
                             <x-form.alerts />
 
-                            <div class="mb-3">
-                                <label for="person_id" class="form-label">Projektleitung <span
-                                        class="text-danger">*</span></label>
-                                <select class="form-control @error('person_id') is-invalid @enderror" id="person_id"
-                                    name="person_id" required>
-                                    <option disabled selected value="">Wählen Sie die Projektleitung aus</option>
-                                    @foreach ($persons as $person)
-                                        <option value="{{ $person->id }}">{{ $person->name }}</option>
-                                    @endforeach
-                                </select>
-                            </div>
+                            <x-form.select
+                                name="person_id"
+                                label="Projektleitung"
+                                :options="$persons"
+                                placeholder="Wählen Sie die Projektleitung aus"
+                                :required="true"
+                            />
 
-                            <div class="mb-3">
-                                <label for="venue_id" class="form-label">Objektname <span
-                                        class="text-danger">*</span></label>
-                                <select class="form-control @error('venue_id') is-invalid @enderror" id="venue_id"
-                                    name="venue_id" required>
-                                    <option disabled selected value="">Wählen Sie den Objektnamen aus</option>
-                                    @foreach ($venues as $venue)
-                                        <option value="{{ $venue->id }}">{{ $venue->name }}</option>
-                                    @endforeach
-                                </select>
-                            </div>
+                            <x-form.select
+                                name="venue_id"
+                                label="Objektname"
+                                :options="$venues"
+                                placeholder="Wählen Sie den Objektnamen aus"
+                                :required="true"
+                            />
 
-                            <div class="mb-3">
-                                <label for="name" class="form-label">Name <span class="text-danger">*</span></label>
-                                <input type="text" class="form-control @error('name') is-invalid @enderror" id="name"
-                                    name="name" required placeholder="Projektname">
-                                <div class="form-text">
-                                    Bitte geben Sie eine eindeutige Bezeichnung für das Projekt an.
-                                </div>
-                            </div>
+                            <x-form.input
+                                name="name"
+                                label="Name"
+                                placeholder="Projektname"
+                                hint="Bitte geben Sie eine eindeutige Bezeichnung für das Projekt an."
+                                :required="true"
+                            />
 
-                            <div class="mb-3">
-                                <label for="description" class="form-label">Beschreibung <span
-                                        class="text-danger">*</span></label>
-                                <textarea class="form-control @error('description') is-invalid @enderror" id="description"
-                                    name="description" rows="3" required placeholder="Projektbeschreibung"></textarea>
-                                <div class="form-text">
-                                    Bitte geben Sie eine Beschreibung für das Projekt an.
-                                </div>
-                            </div>
+                            <x-form.textarea
+                                name="description"
+                                label="Beschreibung"
+                                placeholder="Projektbeschreibung"
+                                hint="Bitte geben Sie eine Beschreibung für das Projekt an."
+                                :required="true"
+                            />
 
-                            <div class="mb-3">
-                                <label for="url" class="form-label">URL <span class="text-danger">*</span></label>
-                                <input type="text" class="form-control @error('url') is-invalid @enderror" id="url"
-                                    name="url" required placeholder="Projekt-URL">
-                                <div class="form-text">
-                                    Bitte geben Sie eine eindeutige URL des Projektes an.
-                                </div>
-                            </div>
+                            <x-form.input
+                                name="url"
+                                label="URL"
+                                placeholder="Projekt-URL"
+                                hint="Bitte geben Sie eine eindeutige URL des Projektes an."
+                                :required="true"
+                            />
 
-                            <div class="mb-3">
-                                <label for="started_at" class="form-label">Beginn <span class="text-danger">*</span></label>
-                                <input type="date" class="form-control @error('started_at') is-invalid @enderror"
-                                    id="started_at" name="started_at" required>
-                                <div class="form-text">
-                                    Bitte geben Sie das Startdatum des Projektes an.
-                                </div>
-                            </div>
+                            <x-form.input
+                                name="started_at"
+                                label="Beginn"
+                                type="date"
+                                hint="Bitte geben Sie das Startdatum des Projektes an."
+                                :required="true"
+                            />
 
-                            <div class="mb-3">
-                                <label for="ended_at" class="form-label">Ende <span class="text-danger">*</span></label>
-                                <input type="date" class="form-control @error('ended_at') is-invalid @enderror"
-                                    id="ended_at" name="ended_at">
-                                @error('ended_at')
-                                    <div class="invalid-feedback">
-                                        {{ $message }}
-                                    </div>
-                                @enderror
-                                <div class="form-text">
-                                    Bitte geben Sie das Enddatum des Projektes an.
-                                </div>
-                            </div>
+                            <x-form.input
+                                name="ended_at"
+                                label="Ende"
+                                type="date"
+                                hint="Bitte geben Sie das Enddatum des Projektes an."
+                                :required="true"
+                            />
 
 
                             <div class="d-flex justify-content-end gap-2">

--- a/resources/views/inputform_project.blade.php
+++ b/resources/views/inputform_project.blade.php
@@ -15,17 +15,7 @@
                         <form method="POST" action="{{ route('inputform_project.store') }}">
                             @csrf
 
-                            @if(session('error'))
-                                <div class="alert alert-danger">
-                                    {{ session('error') }}
-                                </div>
-                            @endif
-
-                            @if(session('success'))
-                                <div class="alert alert-success">
-                                    {{ session('success') }}
-                                </div>
-                            @endif
+                            <x-form.alerts />
 
                             <div class="mb-3">
                                 <label for="person_id" class="form-label">Projektleitung <span

--- a/resources/views/inputform_venue.blade.php
+++ b/resources/views/inputform_venue.blade.php
@@ -13,20 +13,20 @@
 
                         <form action="{{ route('venues.store') }}" method="post">
                             @csrf
-                            <div class="mb-3">
-                                <label for="name" class="form-label">Name: <span class="text-danger">*</span></label>
-                                <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name') }}" required>
-                            </div>
+                            <x-form.input
+                                name="name"
+                                label="Name"
+                                :required="true"
+                            />
 
-                            <div class="mb-3">
-                                <label for="city_id" class="form-label">Stadt: <span class="text-danger">*</span></label>
-                                <select class="form-control @error('city_id') is-invalid @enderror" id="city_id" name="city_id" required>
-                                    <option value="">Bitte auswählen</option>
-                                    @foreach ($cities as $city)
-                                        <option value="{{ $city->id }}" @selected(old('city_id') == $city->id)>{{ $city->full_name }}</option>
-                                    @endforeach
-                                </select>
-                            </div>
+                            <x-form.select
+                                name="city_id"
+                                label="Stadt"
+                                :options="$cities"
+                                option-label="full_name"
+                                placeholder="Bitte auswählen"
+                                :required="true"
+                            />
 
                             <div class="form-text mb-3">
                                 <span class="text-danger">*</span> Pflichtangabe

--- a/resources/views/inputform_venue.blade.php
+++ b/resources/views/inputform_venue.blade.php
@@ -9,27 +9,7 @@
                         <h4 class="mb-0">Neuen Ort hinzufügen</h4>
                     </div>
                     <div class="card-body">
-                        @if ($errors->any())
-                            <div class="alert alert-danger">
-                                <ul class="mb-0">
-                                    @foreach ($errors->all() as $error)
-                                        <li>{{ $error }}</li>
-                                    @endforeach
-                                </ul>
-                            </div>
-                        @endif
-
-                        @if (session('success'))
-                            <div class="alert alert-success">
-                                {{ session('success') }}
-                            </div>
-                        @endif
-
-                        @if (session('error'))
-                            <div class="alert alert-danger">
-                                {{ session('error') }}
-                            </div>
-                        @endif
+                        <x-form.alerts />
 
                         <form action="{{ route('venues.store') }}" method="post">
                             @csrf

--- a/resources/views/institutions/show.blade.php
+++ b/resources/views/institutions/show.blade.php
@@ -16,97 +16,74 @@
             <p class="lead text-muted mb-0">{{ $institution->type }}</p>
         </header>
 
-        <section class="mb-5" aria-labelledby="institution-overview-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary">
-                    <h2 id="institution-overview-title" class="h4 mb-0">Kontakt</h2>
-                </div>
-                <div class="card-body">
-                    <p class="mb-0" aria-label="Kontaktinformationen">{!! nl2br(e($institution->contact_information ?? 'Keine Kontaktdaten hinterlegt.')) !!}</p>
-                </div>
-            </div>
-        </section>
+        <x-card.section id="institution-overview-title" title="Kontakt">
+            <p class="mb-0" aria-label="Kontaktinformationen">{!! nl2br(e($institution->contact_information ?? 'Keine Kontaktdaten hinterlegt.')) !!}</p>
+        </x-card.section>
 
-        <section class="mb-5" aria-labelledby="institution-devices-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary d-flex align-items-center justify-content-between">
-                    <h2 id="institution-devices-title" class="h4 mb-0">Lasergeräte</h2>
-                    <span class="badge text-bg-light">{{ $institution->devices->count() }}</span>
+        <x-card.section id="institution-devices-title" title="Lasergeräte" :count="$institution->devices->count()" class="p-0">
+            @if ($institution->devices->isEmpty())
+                <p class="px-4 py-3 mb-0 text-muted">Es sind keine Geräte hinterlegt.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 align-middle">
+                        <caption class="visually-hidden">Zu dieser Institution gehörende Geräte</caption>
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Name</th>
+                                <th scope="col">Baujahr</th>
+                                <th scope="col">Bauart</th>
+                                <th scope="col" class="text-end">Details</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($institution->devices as $device)
+                                <tr>
+                                    <th scope="row">{{ $device->name }}</th>
+                                    <td>{{ $device->year ?? '–' }}</td>
+                                    <td>{{ $device->build_type }}</td>
+                                    <td class="text-end">
+                                        <a class="btn btn-outline-secondary btn-sm" href="{{ route('devices.show', $device) }}">
+                                            Gerät ansehen
+                                        </a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
                 </div>
-                <div class="card-body p-0">
-                    @if ($institution->devices->isEmpty())
-                        <p class="px-4 py-3 mb-0 text-muted">Es sind keine Geräte hinterlegt.</p>
-                    @else
-                        <div class="table-responsive">
-                            <table class="table table-hover mb-0 align-middle">
-                                <caption class="visually-hidden">Zu dieser Institution gehörende Geräte</caption>
-                                <thead class="table-light">
-                                    <tr>
-                                        <th scope="col">Name</th>
-                                        <th scope="col">Baujahr</th>
-                                        <th scope="col">Bauart</th>
-                                        <th scope="col" class="text-end">Details</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @foreach ($institution->devices as $device)
-                                        <tr>
-                                            <th scope="row">{{ $device->name }}</th>
-                                            <td>{{ $device->year ?? '–' }}</td>
-                                            <td>{{ $device->build_type }}</td>
-                                            <td class="text-end">
-                                                <a class="btn btn-outline-secondary btn-sm" href="{{ route('devices.show', $device) }}">
-                                                    Gerät ansehen
-                                                </a>
-                                            </td>
-                                        </tr>
-                                    @endforeach
-                                </tbody>
-                            </table>
-                        </div>
-                    @endif
-                </div>
-            </div>
-        </section>
+            @endif
+        </x-card.section>
 
-        <section aria-labelledby="institution-persons-title" class="mb-5">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary d-flex align-items-center justify-content-between">
-                    <h2 id="institution-persons-title" class="h4 mb-0">Ansprechpartner*innen</h2>
-                    <span class="badge text-bg-light">{{ $institution->persons->count() }}</span>
+        <x-card.section id="institution-persons-title" title="Ansprechpartner*innen" :count="$institution->persons->count()" class="p-0">
+            @if ($institution->persons->isEmpty())
+                <p class="px-4 py-3 mb-0 text-muted">Es sind keine Personen zugeordnet.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 align-middle">
+                        <caption class="visually-hidden">Personen, die dieser Institution zugeordnet sind</caption>
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Name</th>
+                                <th scope="col">Projekte</th>
+                                <th scope="col" class="text-end">Details</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($institution->persons as $person)
+                                <tr>
+                                    <th scope="row">{{ $person->name }}</th>
+                                    <td>{{ $person->projects->count() }}</td>
+                                    <td class="text-end">
+                                        <a class="btn btn-outline-secondary btn-sm" href="{{ route('persons.show', $person) }}">
+                                            Person ansehen
+                                        </a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
                 </div>
-                <div class="card-body p-0">
-                    @if ($institution->persons->isEmpty())
-                        <p class="px-4 py-3 mb-0 text-muted">Es sind keine Personen zugeordnet.</p>
-                    @else
-                        <div class="table-responsive">
-                            <table class="table table-hover mb-0 align-middle">
-                                <caption class="visually-hidden">Personen, die dieser Institution zugeordnet sind</caption>
-                                <thead class="table-light">
-                                    <tr>
-                                        <th scope="col">Name</th>
-                                        <th scope="col">Projekte</th>
-                                        <th scope="col" class="text-end">Details</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @foreach ($institution->persons as $person)
-                                        <tr>
-                                            <th scope="row">{{ $person->name }}</th>
-                                            <td>{{ $person->projects->count() }}</td>
-                                            <td class="text-end">
-                                                <a class="btn btn-outline-secondary btn-sm" href="{{ route('persons.show', $person) }}">
-                                                    Person ansehen
-                                                </a>
-                                            </td>
-                                        </tr>
-                                    @endforeach
-                                </tbody>
-                            </table>
-                        </div>
-                    @endif
-                </div>
-            </div>
-        </section>
+            @endif
+        </x-card.section>
     </div>
 @endsection

--- a/resources/views/locations/show.blade.php
+++ b/resources/views/locations/show.blade.php
@@ -16,67 +16,51 @@
             <p class="lead text-muted mb-0">{{ $location->venue?->name ?? 'Keine Ortsangabe' }}</p>
         </header>
 
-        <section class="mb-5" aria-labelledby="location-overview-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary">
-                    <h2 id="location-overview-title" class="h4 mb-0">Überblick</h2>
-                </div>
-                <div class="card-body">
-                    <dl class="row g-3 mb-0">
-                        <dt class="col-md-3">Ort</dt>
-                        <dd class="col-md-9">
-                            @if ($location->venue)
-                                <a href="{{ route('venues.show', $location->venue) }}">{{ $location->venue->name }}</a>
-                                <span class="text-muted">{{ $location->venue->city?->full_name }}</span>
-                            @else
-                                <span class="text-muted">Kein Ort hinterlegt.</span>
-                            @endif
-                        </dd>
-                    </dl>
-                </div>
-            </div>
-        </section>
-
-        <section aria-labelledby="location-artifacts-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary d-flex align-items-center justify-content-between">
-                    <h2 id="location-artifacts-title" class="h4 mb-0">Artefakte</h2>
-                    <span class="badge text-bg-light">{{ $location->artifacts->count() }}</span>
-                </div>
-                <div class="card-body p-0">
-                    @if ($location->artifacts->isEmpty())
-                        <p class="px-4 py-3 mb-0 text-muted">Es wurden keine Artefakte für diesen Standort erfasst.</p>
+        <x-card.section id="location-overview-title" title="Überblick">
+            <dl class="row g-3 mb-0">
+                <x-card.data-row label="Ort" dt-class="col-md-3" dd-class="col-md-9">
+                    @if ($location->venue)
+                        <a href="{{ route('venues.show', $location->venue) }}">{{ $location->venue->name }}</a>
+                        <span class="text-muted">{{ $location->venue->city?->full_name }}</span>
                     @else
-                        <div class="table-responsive">
-                            <table class="table table-hover mb-0 align-middle">
-                                <caption class="visually-hidden">Artefakte an diesem Standort</caption>
-                                <thead class="table-light">
-                                    <tr>
-                                        <th scope="col">Name</th>
-                                        <th scope="col">Inventarnummer</th>
-                                        <th scope="col">Probenflächen</th>
-                                        <th scope="col" class="text-end">Details</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @foreach ($location->artifacts as $artifact)
-                                        <tr>
-                                            <th scope="row">{{ $artifact->name }}</th>
-                                            <td>{{ $artifact->inventory_number ?? '–' }}</td>
-                                            <td>{{ $artifact->sampleSurfaces->count() }}</td>
-                                            <td class="text-end">
-                                                <a class="btn btn-outline-secondary btn-sm" href="{{ route('artifacts.show', $artifact) }}">
-                                                    Artefakt ansehen
-                                                </a>
-                                            </td>
-                                        </tr>
-                                    @endforeach
-                                </tbody>
-                            </table>
-                        </div>
+                        <span class="text-muted">Kein Ort hinterlegt.</span>
                     @endif
+                </x-card.data-row>
+            </dl>
+        </x-card.section>
+
+        <x-card.section id="location-artifacts-title" title="Artefakte" :count="$location->artifacts->count()" class="p-0">
+            @if ($location->artifacts->isEmpty())
+                <p class="px-4 py-3 mb-0 text-muted">Es wurden keine Artefakte für diesen Standort erfasst.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 align-middle">
+                        <caption class="visually-hidden">Artefakte an diesem Standort</caption>
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Name</th>
+                                <th scope="col">Inventarnummer</th>
+                                <th scope="col">Probenflächen</th>
+                                <th scope="col" class="text-end">Details</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($location->artifacts as $artifact)
+                                <tr>
+                                    <th scope="row">{{ $artifact->name }}</th>
+                                    <td>{{ $artifact->inventory_number ?? '–' }}</td>
+                                    <td>{{ $artifact->sampleSurfaces->count() }}</td>
+                                    <td class="text-end">
+                                        <a class="btn btn-outline-secondary btn-sm" href="{{ route('artifacts.show', $artifact) }}">
+                                            Artefakt ansehen
+                                        </a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
                 </div>
-            </div>
-        </section>
+            @endif
+        </x-card.section>
     </div>
 @endsection

--- a/resources/views/materials/show.blade.php
+++ b/resources/views/materials/show.blade.php
@@ -28,91 +28,74 @@
             <p class="lead text-muted mb-0">Detailansicht des Materials inklusive Hierarchie und Einsätzen.</p>
         </header>
 
-        <section class="mb-5" aria-labelledby="material-hierarchy-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary">
-                    <h2 id="material-hierarchy-title" class="h4 mb-0">Materialhierarchie</h2>
-                </div>
-                <div class="card-body">
-                    <dl class="row g-3 mb-0">
-                        <dt class="col-lg-3">Übergeordnetes Material</dt>
-                        <dd class="col-lg-9">
-                            @if ($material->parent)
-                                <a href="{{ route('materials.show', $material->parent) }}">{{ $material->parent->name }}</a>
-                            @else
-                                <span class="text-muted">Kein übergeordnetes Material</span>
-                            @endif
-                        </dd>
-
-                        <dt class="col-lg-3">Untergeordnete Materialien</dt>
-                        <dd class="col-lg-9">
-                            @if ($material->children->isEmpty())
-                                <span class="text-muted">Keine weiteren Materialien</span>
-                            @else
-                                <ul class="list-inline mb-0" aria-label="Liste untergeordneter Materialien">
-                                    @foreach ($material->children as $child)
-                                        <li class="list-inline-item mb-1">
-                                            <a class="btn btn-outline-secondary btn-sm" href="{{ route('materials.show', $child) }}">
-                                                {{ $child->name }}
-                                            </a>
-                                        </li>
-                                    @endforeach
-                                </ul>
-                            @endif
-                        </dd>
-                    </dl>
-                </div>
-            </div>
-        </section>
-
-        <section aria-labelledby="material-usage-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary d-flex align-items-center justify-content-between">
-                    <h2 id="material-usage-title" class="h4 mb-0">Einsätze in Teilflächen</h2>
-                    <span class="badge text-bg-light">{{ $partialSurfaces->count() }}</span>
-                </div>
-                <div class="card-body p-0">
-                    @if ($partialSurfaces->isEmpty())
-                        <p class="px-4 py-3 mb-0 text-muted">Dieses Material wurde bisher keiner Teilfläche zugeordnet.</p>
+        <x-card.section id="material-hierarchy-title" title="Materialhierarchie">
+            <dl class="row g-3 mb-0">
+                <x-card.data-row label="Übergeordnetes Material">
+                    @if ($material->parent)
+                        <a href="{{ route('materials.show', $material->parent) }}">{{ $material->parent->name }}</a>
                     @else
-                        <div class="table-responsive">
-                            <table class="table table-hover mb-0 align-middle">
-                                <caption class="visually-hidden">Übersicht der Teilflächen, in denen das Material vorkommt</caption>
-                                <thead class="table-light">
-                                    <tr>
-                                        <th scope="col">Teilfläche</th>
-                                        <th scope="col">Rolle</th>
-                                        <th scope="col">Artefakt</th>
-                                        <th scope="col">Ort</th>
-                                        <th scope="col" class="text-end">Details</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @foreach ($partialSurfaces as $partialSurface)
-                                        <tr>
-                                            <th scope="row">{{ $partialSurface->identifier ?? ('Teilfläche #' . $partialSurface->id) }}</th>
-                                            <td>
-                                                @if ($partialSurface->foundation_material_id === $material->id)
-                                                    Grundmaterial
-                                                @else
-                                                    Beschichtung
-                                                @endif
-                                            </td>
-                                            <td>{{ $partialSurface->sampleSurface?->artifact?->name ?? '–' }}</td>
-                                            <td>{{ $partialSurface->sampleSurface?->artifact?->location?->venue?->name ?? '–' }}</td>
-                                            <td class="text-end">
-                                                <a class="btn btn-outline-secondary btn-sm" href="{{ route('partial_surfaces.show', $partialSurface) }}">
-                                                    Teilfläche ansehen
-                                                </a>
-                                            </td>
-                                        </tr>
-                                    @endforeach
-                                </tbody>
-                            </table>
-                        </div>
+                        <span class="text-muted">Kein übergeordnetes Material</span>
                     @endif
+                </x-card.data-row>
+
+                <x-card.data-row label="Untergeordnete Materialien">
+                    @if ($material->children->isEmpty())
+                        <span class="text-muted">Keine weiteren Materialien</span>
+                    @else
+                        <ul class="list-inline mb-0" aria-label="Liste untergeordneter Materialien">
+                            @foreach ($material->children as $child)
+                                <li class="list-inline-item mb-1">
+                                    <a class="btn btn-outline-secondary btn-sm" href="{{ route('materials.show', $child) }}">
+                                        {{ $child->name }}
+                                    </a>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </x-card.data-row>
+            </dl>
+        </x-card.section>
+
+        <x-card.section id="material-usage-title" title="Einsätze in Teilflächen" :count="$partialSurfaces->count()" class="p-0">
+            @if ($partialSurfaces->isEmpty())
+                <p class="px-4 py-3 mb-0 text-muted">Dieses Material wurde bisher keiner Teilfläche zugeordnet.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 align-middle">
+                        <caption class="visually-hidden">Übersicht der Teilflächen, in denen das Material vorkommt</caption>
+                        <thead class="table-light">
+                            <tr>
+                                <th scope="col">Teilfläche</th>
+                                <th scope="col">Rolle</th>
+                                <th scope="col">Artefakt</th>
+                                <th scope="col">Ort</th>
+                                <th scope="col" class="text-end">Details</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($partialSurfaces as $partialSurface)
+                                <tr>
+                                    <th scope="row">{{ $partialSurface->identifier ?? ('Teilfläche #' . $partialSurface->id) }}</th>
+                                    <td>
+                                        @if ($partialSurface->foundation_material_id === $material->id)
+                                            Grundmaterial
+                                        @else
+                                            Beschichtung
+                                        @endif
+                                    </td>
+                                    <td>{{ $partialSurface->sampleSurface?->artifact?->name ?? '–' }}</td>
+                                    <td>{{ $partialSurface->sampleSurface?->artifact?->location?->venue?->name ?? '–' }}</td>
+                                    <td class="text-end">
+                                        <a class="btn btn-outline-secondary btn-sm" href="{{ route('partial_surfaces.show', $partialSurface) }}">
+                                            Teilfläche ansehen
+                                        </a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
                 </div>
-            </div>
-        </section>
+            @endif
+        </x-card.section>
     </div>
 @endsection

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -18,76 +18,58 @@
             @endif
         </header>
 
-        <section class="mb-5" aria-labelledby="project-summary-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary">
-                    <h2 id="project-summary-title" class="h4 mb-0">Zusammenfassung</h2>
-                </div>
-                <div class="card-body">
-                    <p class="mb-4">{{ $project->description }}</p>
-                    <dl class="row g-3 mb-0">
-                        <dt class="col-md-3">Projektleitung</dt>
-                        <dd class="col-md-9">
-                            @if ($project->person)
-                                <a href="{{ route('persons.show', $project->person) }}">{{ $project->person->name }}</a>
-                                @if ($project->person->institution)
-                                    <span class="text-muted">({{ $project->person->institution->name }})</span>
-                                @endif
-                            @else
-                                <span class="text-muted">Keine Angaben</span>
-                            @endif
-                        </dd>
-
-                        <dt class="col-md-3">Ort</dt>
-                        <dd class="col-md-9">
-                            @if ($project->venue)
-                                <a href="{{ route('venues.show', $project->venue) }}">{{ $project->venue->name }}</a>
-                                @if ($project->venue->city)
-                                    <span class="text-muted">{{ $project->venue->city->full_name }}</span>
-                                @endif
-                            @else
-                                <span class="text-muted">Keine Angaben</span>
-                            @endif
-                        </dd>
-
-                        <dt class="col-md-3">Zeitraum</dt>
-                        <dd class="col-md-9">
-                            {{ optional($project->started_at)->format('d.m.Y') ?? '–' }} –
-                            {{ optional($project->ended_at)->format('d.m.Y') ?? '–' }}
-                        </dd>
-                    </dl>
-                </div>
-            </div>
-        </section>
-
-        <section aria-labelledby="project-media-title">
-            <div class="card shadow-sm">
-                <div class="card-header bg-body-tertiary d-flex align-items-center justify-content-between">
-                    <h2 id="project-media-title" class="h4 mb-0">Medien</h2>
-                    <span class="badge text-bg-light">{{ $project->images->count() }}</span>
-                </div>
-                <div class="card-body">
-                    @if ($project->images->isEmpty())
-                        <p class="mb-0 text-muted">Für dieses Projekt wurden noch keine Medien hinterlegt.</p>
+        <x-card.section id="project-summary-title" title="Zusammenfassung">
+            <p class="mb-4">{{ $project->description }}</p>
+            <dl class="row g-3 mb-0">
+                <x-card.data-row label="Projektleitung" dt-class="col-md-3" dd-class="col-md-9">
+                    @if ($project->person)
+                        <a href="{{ route('persons.show', $project->person) }}">{{ $project->person->name }}</a>
+                        @if ($project->person->institution)
+                            <span class="text-muted">({{ $project->person->institution->name }})</span>
+                        @endif
                     @else
-                        <div class="row g-4">
-                            @foreach ($project->images as $image)
-                                <article class="col-md-6 col-lg-4" aria-label="Bild {{ $loop->iteration }}">
-                                    <div class="card h-100 shadow-sm">
-                                        <div class="ratio ratio-4x3 bg-body-secondary rounded-top">
-                                            <img src="{{ Storage::url($image->uri) }}" alt="{{ $image->alt_text }}" class="w-100 h-100 object-fit-cover rounded-top">
-                                        </div>
-                                        <div class="card-body">
-                                            <h3 class="h6">{{ $image->description ?? 'Ohne Beschreibung' }}</h3>
-                                            <p class="text-muted small mb-0">{{ $image->creator }} · {{ $image->year_created }}</p>
-                                        </div>
-                                    </div>
-                                </article>
-                            @endforeach
-                        </div>
+                        <span class="text-muted">Keine Angaben</span>
                     @endif
+                </x-card.data-row>
+
+                <x-card.data-row label="Ort" dt-class="col-md-3" dd-class="col-md-9">
+                    @if ($project->venue)
+                        <a href="{{ route('venues.show', $project->venue) }}">{{ $project->venue->name }}</a>
+                        @if ($project->venue->city)
+                            <span class="text-muted">{{ $project->venue->city->full_name }}</span>
+                        @endif
+                    @else
+                        <span class="text-muted">Keine Angaben</span>
+                    @endif
+                </x-card.data-row>
+
+                <x-card.data-row label="Zeitraum" dt-class="col-md-3" dd-class="col-md-9">
+                    {{ optional($project->started_at)->format('d.m.Y') ?? '–' }} –
+                    {{ optional($project->ended_at)->format('d.m.Y') ?? '–' }}
+                </x-card.data-row>
+            </dl>
+        </x-card.section>
+
+        <x-card.section id="project-media-title" title="Medien" :count="$project->images->count()">
+            @if ($project->images->isEmpty())
+                <p class="mb-0 text-muted">Für dieses Projekt wurden noch keine Medien hinterlegt.</p>
+            @else
+                <div class="row g-4">
+                    @foreach ($project->images as $image)
+                        <article class="col-md-6 col-lg-4" aria-label="Bild {{ $loop->iteration }}">
+                            <div class="card h-100 shadow-sm">
+                                <div class="ratio ratio-4x3 bg-body-secondary rounded-top">
+                                    <img src="{{ Storage::url($image->uri) }}" alt="{{ $image->alt_text }}" class="w-100 h-100 object-fit-cover rounded-top">
+                                </div>
+                                <div class="card-body">
+                                    <h3 class="h6">{{ $image->description ?? 'Ohne Beschreibung' }}</h3>
+                                    <p class="text-muted small mb-0">{{ $image->creator }} · {{ $image->year_created }}</p>
+                                </div>
+                            </div>
+                        </article>
+                    @endforeach
                 </div>
-            </div>
-        </section>
+            @endif
+        </x-card.section>
     </div>
 @endsection


### PR DESCRIPTION
This pull request introduces a set of reusable Blade components for form elements and card sections, and refactors the artifact and device show views to use these new components. The goal is to standardize the UI, improve code maintainability, and reduce duplication.

## Changes & Rationale
### Introduction of reusable components:
- **Form components:**
  - Added new Blade components and corresponding PHP classes for form elements: `Input`, `Select`, and `Textarea`, each supporting common attributes, validation, and hint display. [[1]](diffhunk://#diff-dd4aea844545ff3dd642752861352eb8dc8db17d88b518871ed942648740bf40R1-R28) [[2]](diffhunk://#diff-1125883214929cfe7a3852178c47851fb520c886576e0c7092f737908c5c1c04R1-R28) [[3]](diffhunk://#diff-c8c7c7d4a83e8f97fd575a167cf6fd869937cddd67d0e6aa650c6704ccb62d83R1-R25) [[4]](diffhunk://#diff-3031dd46f5c37e87d375736e7c5acdc04ec4601afa13a10fd80bd80649ff8e70R1-R43) [[5]](diffhunk://#diff-317f184a92b02cc194c3a8a05dc7a5936f0149096b99bff779d867b48911b981R1-R56) [[6]](diffhunk://#diff-3f05f8b8dce8c0c3f004646973e59a6a416a46ded371bd3c8f54a4e637eb6829R1-R36)
  - Added a `form/alerts` component to display validation errors, session messages, and an optional required fields hint.

- **Card and data display components:**
  - Introduced a `card/section` component for consistent card-based section layouts, supporting titles, badges, and flexible content.
  - Added a `card/data-row` component for rendering definition list rows with labels and values, including fallback values and slot support.
  - Added a `card/form` component for wrapping forms in a styled card layout.

### Refactoring of artifact and device show views
- Refactored `artifacts/show.blade.php` and `devices/show.blade.php` to use the new `x-card.section` and `x-card.data-row` components, replacing manual card markup and definition lists for a more modular and readable structure. [[1]](diffhunk://#diff-bdd01da2f949aaf54bbe5ea5e8e53dbdc2baa503e94ae31a633e3c88f6442a42L19-R34) [[2]](diffhunk://#diff-bdd01da2f949aaf54bbe5ea5e8e53dbdc2baa503e94ae31a633e3c88f6442a42L79-R64) [[3]](diffhunk://#diff-59fac74e1f21fc16d7286f086f93be702ec271e949659415e28dbc221917315dL27-R50) [[4]](diffhunk://#diff-59fac74e1f21fc16d7286f086f93be702ec271e949659415e28dbc221917315dL114-R93) [[5]](diffhunk://#diff-59fac74e1f21fc16d7286f086f93be702ec271e949659415e28dbc221917315dL142-R113) [[6]](diffhunk://#diff-59fac74e1f21fc16d7286f086f93be702ec271e949659415e28dbc221917315dL196-R157)

## Related Issues
<!-- Example: Closes #123, Fixes #456 -->

## Definition of Done Checklist

- [ ] User story requirements met
- [ ] Documentation updated
- [x] New code covered by unit tests
- [x] All unit tests pass locally
- [x] Manually tested
- [x] Works on desktop devices
- [x] Works on mobile devices

## Laravel-Specific Changes

- [ ] Migrations
- [ ] Models
- [x] Views
- [ ] Routes
- [ ] Seeders
- [ ] Config
- [ ] Artisan commands

## Infrastructure & Tooling Changes

- [ ] PHP dependencies
- [ ] Node.js dependencies
- [ ] Tooling/scripts
- [ ] CI/CD workflows
- [ ] Repository meta/templates

## Additional Notes
<!-- Add any extra context for reviewers and contributors -->
